### PR TITLE
New cloud attachment type

### DIFF
--- a/Source/Plugins/Core/com.equella.base/src/com/tle/beans/item/attachments/CustomAttachment.java
+++ b/Source/Plugins/Core/com.equella.base/src/com/tle/beans/item/attachments/CustomAttachment.java
@@ -40,6 +40,22 @@ public class CustomAttachment extends Attachment {
     return value1;
   }
 
+  public String getValue2() {
+    return value2;
+  }
+
+  public String getValue3() {
+    return value3;
+  }
+
+  public void setValue2(String value2) {
+    this.value2 = value2;
+  }
+
+  public void setValue3(String value3) {
+    this.value3 = value3;
+  }
+
   @Override
   public AttachmentType getAttachmentType() {
     return AttachmentType.CUSTOM;

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentEditor.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentEditor.scala
@@ -1,9 +1,11 @@
 /*
- * Copyright 2017 Apereo
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentEditor.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentEditor.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.core.cloudproviders
+
+import java.util.UUID
+
+import com.tle.beans.item.attachments.{Attachment, CustomAttachment}
+import com.tle.core.item.edit.attachment.AbstractCustomAttachmentEditor
+import io.circe.Json
+
+class CloudAttachmentEditor extends AbstractCustomAttachmentEditor {
+  def finish() = {
+    CloudAttachmentJson.encodeJson(customAttachment, cloudJson)
+  }
+
+  var cloudJson: CloudAttachmentJson = null
+
+  override def setAttachment(attachment: Attachment): Unit = {
+    super.setAttachment(attachment)
+    cloudJson = CloudAttachmentJson.decodeJson(attachment.asInstanceOf[CustomAttachment])
+  }
+
+  def editVendorId(vendorId: String): Unit = customAttachment.setValue3(vendorId)
+
+  def editCloudType(cloudType: String): Unit = customAttachment.setValue2(cloudType)
+
+  def editProviderId(providerId: UUID): Unit = {
+    cloudJson = cloudJson.copy(providerId = providerId)
+  }
+
+  def editDisplay(display: Option[Map[String, Json]]): Unit = {
+    cloudJson = cloudJson.copy(display = display)
+  }
+
+  def editMeta(meta: Option[Map[String, Json]]): Unit = {
+    cloudJson = cloudJson.copy(meta = meta)
+  }
+
+  override def getCustomType: String = "cloud"
+
+  override def newAttachment(): Attachment = {
+    val attach = super.newAttachment()
+    CloudAttachmentJson.encodeJson(attach.asInstanceOf[CustomAttachment],
+                                   CloudAttachmentJson.defaultJson)
+    attach
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentJson.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentJson.scala
@@ -1,9 +1,11 @@
 /*
- * Copyright 2017 Apereo
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentJson.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentJson.scala
@@ -21,8 +21,8 @@ package com.tle.core.cloudproviders
 import java.util.UUID
 
 import com.tle.beans.item.attachments.CustomAttachment
-import io.circe.generic.semiauto._
 import io.circe.Json
+import io.circe.generic.semiauto._
 import io.circe.parser._
 
 case class CloudAttachmentJson(providerId: UUID,

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentJson.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentJson.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.core.cloudproviders
+
+import java.util.UUID
+
+import com.tle.beans.item.attachments.CustomAttachment
+import io.circe.generic.semiauto._
+import io.circe.Json
+import io.circe.parser._
+
+case class CloudAttachmentJson(providerId: UUID,
+                               display: Option[Map[String, Json]],
+                               meta: Option[Map[String, Json]])
+
+object CloudAttachmentJson {
+  val defaultJson = CloudAttachmentJson(new UUID(0L, 0L), None, None)
+
+  final val JsonField = "json"
+  val encode          = deriveEncoder[CloudAttachmentJson]
+  val decode          = deriveDecoder[CloudAttachmentJson]
+
+  def decodeJson(attachment: CustomAttachment): CloudAttachmentJson = {
+    parse(attachment.getData(JsonField).asInstanceOf[String])
+      .flatMap(CloudAttachmentJson.decode.decodeJson)
+      .getOrElse(defaultJson)
+  }
+
+  def encodeJson(attachment: CustomAttachment, data: CloudAttachmentJson): Unit = {
+    attachment.setData(JsonField, encode(data).noSpaces)
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentResourceExtension.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentResourceExtension.scala
@@ -1,9 +1,11 @@
 /*
- * Copyright 2017 Apereo
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentResourceExtension.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentResourceExtension.scala
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.core.cloudproviders
+
+import java.io.{InputStream, OutputStream}
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.util
+
+import cats.data.OptionT
+import cats.effect.IO
+import com.softwaremill.sttp._
+import com.tle.beans.item.attachments.{CustomAttachment, IAttachment}
+import com.tle.core.db.{DB, RunWithDB}
+import com.tle.web.sections.render.TextLabel
+import com.tle.web.sections.standard.model.SimpleBookmark
+import com.tle.web.sections.{Bookmark, SectionInfo}
+import com.tle.web.stream.{AbstractContentStream, ContentStream}
+import com.tle.web.viewurl.{AttachmentDetail, ViewableResource}
+import com.tle.web.viewurl.attachments.AttachmentResourceExtension
+import com.tle.web.viewurl.resource.AbstractWrappedResource
+import fs2.Stream
+import io.circe.Json.Folder
+import io.circe.{Json, JsonNumber, JsonObject}
+
+import scala.collection.JavaConverters._
+
+class CloudAttachmentResourceExtension extends AttachmentResourceExtension[IAttachment] {
+  override def process(info: SectionInfo,
+                       resource: ViewableResource,
+                       attachment: IAttachment): ViewableResource = attachment match {
+    case attach: CustomAttachment => CloudAttachmentViewableResource(info, resource, attach)
+  }
+}
+
+case class CloudAttachmentViewableResource(info: SectionInfo,
+                                           parent: ViewableResource,
+                                           attach: CustomAttachment)
+    extends AbstractWrappedResource(parent) {
+
+  val fields      = CloudAttachmentFields(attach)
+  lazy val itemId = parent.getViewableItem.getItemId
+  lazy val directLink = RunWithDB.executeWithHibernate {
+    (for {
+      cp <- CloudProviderDB.get(fields.providerId)
+      viewerDeets <- OptionT.fromOption[DB](
+        serviceUriForViewer(cp, "").filterNot(_._2.authenticated))
+      viewerUri <- OptionT {
+        CloudProviderService.serviceUri(cp, viewerDeets._2, uriParameters).map(_.toOption)
+      }
+    } yield viewerUri).value
+  }
+
+  def serviceUriForViewer(provider: CloudProviderInstance,
+                          viewerId: String): Option[(Viewer, ServiceUri)] =
+    for {
+      viewerMap  <- provider.viewers.get(fields.cloudType)
+      viewer     <- viewerMap.get(viewerId)
+      serviceUri <- provider.serviceUris.get(viewer.serviceId)
+    } yield (viewer, serviceUri)
+
+  def uriParameters: Map[String, Any] = {
+    val metaParams =
+      fields.cloudJson.meta.map(_.mapValues(_.foldWith(MetaJsonFolder))).getOrElse(Map.empty)
+    Map("item" -> itemId.getUuid, "version" -> itemId.getVersion, "attachment" -> attach.getUuid) ++ metaParams
+  }
+
+  override def getCommonAttachmentDetails: util.List[AttachmentDetail] = {
+    fields.cloudJson.display
+      .getOrElse(Map.empty)
+      .map {
+        case (name, value) =>
+          AbstractWrappedResource.makeDetail(
+            new TextLabel(name + ":"),
+            new TextLabel(value.foldWith(CloudAttachmentSerializer.javaFolder).toString))
+      }
+      .toBuffer
+      .asJava
+  }
+
+  override def isExternalResource: Boolean = true
+
+  override def createCanonicalUrl(): Bookmark =
+    directLink.map(uri => new SimpleBookmark(uri.toString())).getOrElse {
+      super.createCanonicalUrl()
+    }
+
+  override def hasContentStream: Boolean = directLink.isEmpty
+
+  override def getContentStream: ContentStream = {
+    RunWithDB.executeWithHibernate {
+      (for {
+        provider      <- CloudProviderDB.get(fields.providerId)
+        viewerDetails <- OptionT.fromOption[DB] { serviceUriForViewer(provider, "") }
+        response <- OptionT.liftF(
+          CloudProviderService.serviceRequest(
+            viewerDetails._2,
+            provider,
+            uriParameters,
+            uri => sttp.get(uri).response(asStream[Stream[IO, ByteBuffer]])))
+      } yield response).value
+    } match {
+      case None => EmptyResponseStream
+      case Some(response) =>
+        response.body match {
+          case Right(responseStream) => SttpResponseContentStream(response, responseStream)
+          case Left(failure)         => sys.error(failure)
+        }
+    }
+  }
+
+}
+
+object MetaJsonFolder extends Folder[Any] {
+  override def onNull: Any = None
+
+  override def onBoolean(value: Boolean): Any = value
+
+  override def onNumber(value: JsonNumber): Any =
+    value.toLong
+      .getOrElse(value.toDouble)
+
+  override def onString(value: String): Any = value
+
+  override def onArray(value: Vector[Json]): Any = value.map(_.foldWith(this))
+
+  override def onObject(value: JsonObject): Any =
+    value.toMap.mapValues(_.foldWith(this))
+}
+
+case class SttpResponseContentStream(response: Response[fs2.Stream[IO, ByteBuffer]],
+                                     responseStream: fs2.Stream[IO, ByteBuffer])
+    extends AbstractContentStream(null, response.contentType.orNull) {
+  override def getContentLength: Long      = response.contentLength.getOrElse(-1L)
+  override def getInputStream: InputStream = null
+  override def mustWrite(): Boolean        = true
+  override def write(out: OutputStream): Unit = {
+    val channel = Channels.newChannel(out)
+    responseStream.evalMap(bb => IO(channel.write(bb))).compile.drain.unsafeRunSync()
+  }
+}
+
+object EmptyResponseStream extends AbstractContentStream(null, null) {
+  override def getInputStream: InputStream = null
+  override def getContentLength: Long      = 0L
+  override def exists(): Boolean           = false
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentResourceExtension.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentResourceExtension.scala
@@ -32,9 +32,9 @@ import com.tle.web.sections.render.TextLabel
 import com.tle.web.sections.standard.model.SimpleBookmark
 import com.tle.web.sections.{Bookmark, SectionInfo}
 import com.tle.web.stream.{AbstractContentStream, ContentStream}
-import com.tle.web.viewurl.{AttachmentDetail, ViewableResource}
 import com.tle.web.viewurl.attachments.AttachmentResourceExtension
 import com.tle.web.viewurl.resource.AbstractWrappedResource
+import com.tle.web.viewurl.{AttachmentDetail, ViewableResource}
 import fs2.Stream
 import io.circe.Json.Folder
 import io.circe.{Json, JsonNumber, JsonObject}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentSerializer.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentSerializer.scala
@@ -1,9 +1,11 @@
 /*
- * Copyright 2017 Apereo
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentSerializer.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentSerializer.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.core.cloudproviders
+
+import java.util
+import java.util.UUID
+
+import com.google.common.collect.ImmutableMap
+import com.tle.beans.item.attachments.{Attachment, CustomAttachment}
+import com.tle.core.item.edit.ItemEditor
+import com.tle.core.item.serializer.AbstractAttachmentSerializer
+import com.tle.web.api.item.equella.interfaces.beans.{CloudAttachmentBean, EquellaAttachmentBean}
+import io.circe.{Json, JsonNumber, JsonObject}
+import io.circe.Json.Folder
+import scala.collection.JavaConverters._
+import io.circe.syntax._
+
+class CloudAttachmentSerializer extends AbstractAttachmentSerializer {
+  import CloudAttachmentSerializer._
+  override def serialize(attachment: Attachment): EquellaAttachmentBean = attachment match {
+    case a: CustomAttachment =>
+      val cab    = new CloudAttachmentBean()
+      val fields = CloudAttachmentFields(a)
+      cab.setCloudType(fields.cloudType)
+      cab.setVendorId(fields.vendorId)
+      cab.setProviderId(fields.providerId)
+      cab.setDisplay(toJavaMap(fields.cloudJson.display))
+      cab.setMeta(toJavaMap(fields.cloudJson.meta))
+      cab
+  }
+
+  override def deserialize(bean: EquellaAttachmentBean, itemEditor: ItemEditor): String =
+    bean match {
+      case cloudBean: CloudAttachmentBean =>
+        val uuid   = bean.getUuid
+        val editor = itemEditor.getAttachmentEditor(uuid, classOf[CloudAttachmentEditor])
+        editStandard(editor, cloudBean)
+        editor.editProviderId(cloudBean.getProviderId)
+        editor.editVendorId(cloudBean.getVendorId)
+        editor.editCloudType(cloudBean.getCloudType)
+        editor.editDisplay(toScalaMap(cloudBean.getDisplay))
+        editor.editMeta(toScalaMap(cloudBean.getMeta))
+        editor.finish()
+        editor.getAttachmentUuid
+    }
+
+  def toJavaMap(smap: Option[Map[String, Json]]): java.util.Map[String, Object] =
+    smap.map(_.mapValues(_.foldWith(javaFolder)).asJava).orNull
+
+  def toScalaMap(jmap: java.util.Map[String, Object]): Option[Map[String, Json]] =
+    Option(jmap).map(_.asScala.mapValues(fromJava).toMap)
+
+  override def getAttachmentBeanTypes: util.Map[String, Class[_ <: EquellaAttachmentBean]] =
+    ImmutableMap.of("cloud", classOf[CloudAttachmentBean])
+
+  override def exportable(bean: EquellaAttachmentBean): Boolean = false
+
+}
+
+case class CloudAttachmentFields(attachment: CustomAttachment) {
+  val cloudJson         = CloudAttachmentJson.decodeJson(attachment)
+  def cloudType: String = attachment.getValue2
+  def vendorId: String  = attachment.getValue3
+  def providerId: UUID  = cloudJson.providerId
+}
+
+object CloudAttachmentSerializer {
+  val javaFolder = new Folder[Object] {
+    override def onNull: AnyRef = null
+
+    override def onBoolean(value: Boolean): AnyRef = value.asInstanceOf[AnyRef]
+
+    override def onNumber(value: JsonNumber): AnyRef =
+      value.toLong
+        .map(_.asInstanceOf[java.lang.Long])
+        .getOrElse(value.toDouble.asInstanceOf[java.lang.Double])
+
+    override def onString(value: String): AnyRef = value
+
+    override def onArray(value: Vector[Json]): AnyRef = value.map(_.foldWith(this)).asJava
+
+    override def onObject(value: JsonObject): AnyRef =
+      value.toMap.mapValues(_.foldWith(this)).asJava
+  }
+
+  def fromJava(obj: Any): Json = obj match {
+    case s: String                  => s.asJson
+    case n: java.lang.Long          => n.asJson
+    case i: java.lang.Integer       => i.asJson
+    case b: java.lang.Boolean       => b.asJson
+    case a: java.util.Collection[_] => a.asScala.map(fromJava).asJson
+    case m: java.util.Map[_, _] =>
+      m.asScala.map {
+        case (k, v) => (k.toString, fromJava(v))
+      }.asJson
+  }
+
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentSerializer.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentSerializer.scala
@@ -26,10 +26,11 @@ import com.tle.beans.item.attachments.{Attachment, CustomAttachment}
 import com.tle.core.item.edit.ItemEditor
 import com.tle.core.item.serializer.AbstractAttachmentSerializer
 import com.tle.web.api.item.equella.interfaces.beans.{CloudAttachmentBean, EquellaAttachmentBean}
-import io.circe.{Json, JsonNumber, JsonObject}
 import io.circe.Json.Folder
-import scala.collection.JavaConverters._
 import io.circe.syntax._
+import io.circe.{Json, JsonNumber, JsonObject}
+
+import scala.collection.JavaConverters._
 
 class CloudAttachmentSerializer extends AbstractAttachmentSerializer {
   import CloudAttachmentSerializer._

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderDB.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderDB.scala
@@ -21,23 +21,21 @@ package com.tle.core.cloudproviders
 import java.util.concurrent.TimeUnit
 import java.util.{Locale, UUID}
 
-import cats.syntax.apply._
-import cats.syntax.functor._
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{OptionT, ValidatedNec}
 import cats.effect.{IO, LiftIO}
-import cats.syntax.validated._
-
 import cats.syntax.applicative._
+import cats.syntax.apply._
+import cats.syntax.validated._
 import com.tle.core.db._
 import com.tle.core.db.dao.{EntityDB, EntityDBExt}
 import com.tle.core.db.tables.OEQEntity
 import com.tle.core.validation.{EntityValidation, OEQEntityEdits}
 import com.tle.legacy.LegacyGuice
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import fs2.Stream
+import io.circe.generic.semiauto._
 import io.doolse.simpledba.Iso
 import io.doolse.simpledba.circe.circeJsonUnsafe
-import fs2.Stream
 
 case class CloudProviderData(baseUrl: String,
                              iconUrl: Option[String],
@@ -49,7 +47,12 @@ case class CloudProviderData(baseUrl: String,
 
 object CloudProviderData {
 
-  import io.circe.generic.auto._
+  implicit val decoderV = deriveDecoder[Viewer]
+  implicit val encoderV = deriveEncoder[Viewer]
+  implicit val decoderS = deriveDecoder[ServiceUri]
+  implicit val encoderS = deriveEncoder[ServiceUri]
+  implicit val decoderC = deriveDecoder[CloudOAuthCredentials]
+  implicit val encoderC = deriveEncoder[CloudOAuthCredentials]
 
   implicit val decoder = deriveDecoder[CloudProviderData]
   implicit val encoder = deriveEncoder[CloudProviderData]

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderService.scala
@@ -22,8 +22,8 @@ import java.nio.ByteBuffer
 import java.time.Instant
 
 import cats.effect.IO
-import cats.syntax.either._
 import cats.syntax.applicative._
+import cats.syntax.either._
 import com.softwaremill.sttp._
 import com.softwaremill.sttp.circe._
 import com.tle.beans.cloudproviders.{CloudControlDefinition, ProviderControlDefinition}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderService.scala
@@ -60,10 +60,10 @@ object CloudProviderService {
   }
 
   def serviceUri(provider: CloudProviderInstance,
-                 serviceId: String,
-                 params: Map[String, String]): Option[Uri] = {
-    provider.serviceUris.get(serviceId).flatMap { serviceUri =>
-      UriTemplateService.replaceVariables(serviceUri.uri, provider.baseUrl, params).toOption
+                 serviceUri: ServiceUri,
+                 params: Map[String, Any]): DB[Either[UriParseError, Uri]] = {
+    contextParams.map { ctxParams =>
+      UriTemplateService.replaceVariables(serviceUri.uri, provider.baseUrl, ctxParams ++ params)
     }
   }
 

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/UriTemplateService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/UriTemplateService.scala
@@ -18,10 +18,7 @@
 
 package com.tle.core.cloudproviders
 
-import java.net.URI
-
-import com.softwaremill.sttp.UriInterpolator
-import com.softwaremill.sttp.Uri
+import com.softwaremill.sttp.{Uri, UriInterpolator}
 
 import scala.util.parsing.combinator.{JavaTokenParsers, RegexParsers}
 

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/package.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/package.scala
@@ -17,7 +17,6 @@
  */
 
 package com.tle.core
-import java.net.URI
 import java.util.UUID
 
 import com.tle.beans.Institution

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/item/edit/attachment/AttachmentEditorProvider.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/item/edit/attachment/AttachmentEditorProvider.scala
@@ -1,9 +1,11 @@
 /*
- * Copyright 2017 Apereo
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/item/edit/attachment/AttachmentEditorProvider.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/item/edit/attachment/AttachmentEditorProvider.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.core.item.edit.attachment
+
+import com.tle.beans.item.ItemEditingException
+import com.tle.core.cloudproviders.CloudAttachmentEditor
+import com.tle.legacy.LegacyGuice
+
+object AttachmentEditorProvider {
+
+  private val tracker = LegacyGuice.attachEditorTracker
+
+  def createEditorForType(className: String): AbstractAttachmentEditor = {
+    val extMap = tracker.getExtensionMap
+    Option(extMap.get(className)).map(tracker.getNewBeanByExtension).getOrElse {
+      className match {
+        case c if c == classOf[CloudAttachmentEditor].getName => new CloudAttachmentEditor()
+        case _ =>
+          throw new ItemEditingException(
+            s"No extension for '$className' ${classOf[CloudAttachmentEditor].getName}")
+      }
+    }
+  }
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
@@ -18,7 +18,7 @@
 
 package com.tle.web.api.wizard
 
-import java.io.{IOException, InputStream, OutputStream}
+import java.io.{InputStream, OutputStream}
 import java.nio.ByteBuffer
 import java.nio.channels.Channels
 import java.util.UUID
@@ -29,29 +29,25 @@ import com.dytech.devlib.PropBagEx
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id
 import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+import com.softwaremill.sttp._
 import com.tle.beans.item.{Item, ItemEditingException, ItemPack}
+import com.tle.common.filesystem.FileEntry
 import com.tle.core.cloudproviders.{CloudProviderDB, CloudProviderService}
 import com.tle.core.db.{DB, RunWithDB}
+import com.tle.core.httpclient._
 import com.tle.core.item.operations.{ItemOperationParams, WorkflowOperation}
-import com.tle.core.item.serializer.impl.AttachmentSerializerProvider
-import com.tle.core.item.standard.operations.{
-  AbstractStandardWorkflowOperation,
-  DuringSaveOperation
-}
+import com.tle.core.item.standard.operations.DuringSaveOperation
 import com.tle.legacy.LegacyGuice
 import com.tle.web.api.item.equella.interfaces.beans.EquellaAttachmentBean
-import com.tle.web.wizard.{WizardState, WizardStateInterface}
 import com.tle.web.wizard.impl.WizardServiceImpl.WizardSessionState
-import io.swagger.annotations.Api
-import javax.servlet.http.HttpServletRequest
-import javax.ws.rs.core.{Context, Response, StreamingOutput, UriInfo}
-import javax.ws.rs.{GET, POST, PUT, Path, PathParam, QueryParam, WebApplicationException}
-import com.softwaremill.sttp._
-import com.tle.common.filesystem.FileEntry
-import javax.ws.rs.core.Response.{ResponseBuilder, Status}
+import com.tle.web.wizard.{WizardState, WizardStateInterface}
 import fs2.Stream
 import fs2.io._
-import com.tle.core.httpclient._
+import io.swagger.annotations.Api
+import javax.servlet.http.HttpServletRequest
+import javax.ws.rs.core.Response.{ResponseBuilder, Status}
+import javax.ws.rs.core.{Context, Response, StreamingOutput, UriInfo}
+import javax.ws.rs._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardItemEditor.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardItemEditor.scala
@@ -25,7 +25,7 @@ import com.dytech.devlib.PropBagEx
 import com.tle.beans.item.attachments.Attachment
 import com.tle.beans.item.{ItemEditingException, ItemIdKey}
 import com.tle.common.filesystem.handle.FileHandle
-import com.tle.core.item.edit.attachment.AttachmentEditor
+import com.tle.core.item.edit.attachment.{AttachmentEditor, AttachmentEditorProvider}
 import com.tle.core.item.edit.impl.ItemEditorImpl
 import com.tle.core.item.edit.{DRMEditor, ItemEditor, ItemEditorChangeTracker, NavigationEditor}
 import com.tle.legacy.LegacyGuice
@@ -37,9 +37,8 @@ import scala.collection.mutable
 
 class WizardItemEditor(wsi: WizardStateInterface) extends ItemEditor with ItemEditorChangeTracker {
 
-  val item                = wsi.getItem
-  val attachEditorTracker = LegacyGuice.attachEditorTracker
-  val fileHandle          = wsi.getFileHandle
+  val item       = wsi.getItem
+  val fileHandle = wsi.getFileHandle
 
   val attachmentMap   = mutable.Map[String, Attachment]()
   val attachmentOrder = mutable.Buffer[String]()
@@ -97,11 +96,7 @@ class WizardItemEditor(wsi: WizardStateInterface) extends ItemEditor with ItemEd
         ItemEditorImpl.checkValidUuid(exUuid)
         (exUuid, attachmentMap.get(exUuid))
     }
-    val extMap    = attachEditorTracker.getExtensionMap
-    val extension = extMap.get(`type`.getName)
-    if (extension == null)
-      throw new ItemEditingException("No extension for '" + `type`.getName + "'")
-    val attachEditor = attachEditorTracker.getNewBeanByExtension(extension)
+    val attachEditor = AttachmentEditorProvider.createEditorForType(`type`.getName)
     attachEditor.setItemEditorChangeTracker(this)
     attachEditor.setItem(item)
     attachEditor.setFileHandle(fileHandle)

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/edit/impl/ItemEditorImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/edit/impl/ItemEditorImpl.java
@@ -64,6 +64,7 @@ import com.tle.core.item.edit.ItemMetadataListener;
 import com.tle.core.item.edit.NavigationEditor;
 import com.tle.core.item.edit.attachment.AbstractAttachmentEditor;
 import com.tle.core.item.edit.attachment.AttachmentEditor;
+import com.tle.core.item.edit.attachment.AttachmentEditorProvider;
 import com.tle.core.item.event.IndexItemBackgroundEvent;
 import com.tle.core.item.event.IndexItemNowEvent;
 import com.tle.core.item.helper.ItemHelper;
@@ -92,7 +93,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import javax.inject.Inject;
-import org.java.plugin.registry.Extension;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -100,7 +100,6 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public final class ItemEditorImpl implements ItemEditor, DeleteHandler, ItemEditorChangeTracker {
   private static final String SAVE_SCRIPT_NAME = "saveOperation";
 
-  @Inject private PluginTracker<AbstractAttachmentEditor> attachEditorTracker;
   @Inject private PluginTracker<ItemMetadataListener> metadataListenerTracker;
   @Inject private PluginTracker<ItemAttachmentListener> attachmentListenerTracker;
   @Inject private ItemService itemService;
@@ -308,12 +307,8 @@ public final class ItemEditorImpl implements ItemEditor, DeleteHandler, ItemEdit
         checkValidUuid(uuid);
       }
     }
-    Map<String, Extension> extMap = attachEditorTracker.getExtensionMap();
-    Extension extension = extMap.get(type.getName());
-    if (extension == null) {
-      throw new ItemEditingException("No extension for '" + type.getName() + "'");
-    }
-    AbstractAttachmentEditor attachEditor = attachEditorTracker.getNewBeanByExtension(extension);
+    AbstractAttachmentEditor attachEditor =
+        AttachmentEditorProvider.createEditorForType(type.getName());
     attachEditor.setItemEditorChangeTracker(this);
     attachEditor.setItem(item);
     attachEditor.setFileHandle(fileHandle);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/serializer/impl/AttachmentSerializerProvider.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/serializer/impl/AttachmentSerializerProvider.java
@@ -51,7 +51,7 @@ import javax.inject.Singleton;
 public class AttachmentSerializerProvider implements ItemSerializerProvider, MapperExtension {
   private static final String ALIAS_ATTACHMENTS = "attachments";
 
-  @Inject private PluginTracker<AttachmentSerializer> _tracker;
+  @Inject private PluginTracker<AttachmentSerializer> tracker;
   @Inject private ItemDao itemDao;
 
   private Map<String, AttachmentSerializer> serializerMap;
@@ -148,7 +148,7 @@ public class AttachmentSerializerProvider implements ItemSerializerProvider, Map
 
   public synchronized Map<String, AttachmentSerializer> getAttachmentSerializers() {
     if (serializerMap == null) {
-      serializerMap = _tracker.getNewBeanMap();
+      serializerMap = tracker.getNewBeanMap();
       serializerMap.put("custom/cloud", new CloudAttachmentSerializer());
     }
     return serializerMap;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/serializer/impl/StandardDeserializerEditor.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/core/item/serializer/impl/StandardDeserializerEditor.java
@@ -33,7 +33,6 @@ import com.tle.core.item.edit.NavigationEditor;
 import com.tle.core.item.edit.NavigationNodeEditor;
 import com.tle.core.item.serializer.AttachmentSerializer;
 import com.tle.core.item.serializer.ItemDeserializerEditor;
-import com.tle.core.plugins.PluginTracker;
 import com.tle.web.api.interfaces.beans.UserBean;
 import com.tle.web.api.item.equella.interfaces.beans.EquellaAttachmentBean;
 import com.tle.web.api.item.equella.interfaces.beans.EquellaItemBean;
@@ -56,7 +55,7 @@ import javax.inject.Singleton;
 @Bind
 @Singleton
 public class StandardDeserializerEditor implements ItemDeserializerEditor {
-  @Inject private PluginTracker<AttachmentSerializer> attachmentDeserializers;
+  @Inject private AttachmentSerializerProvider attachmentDeserializers;
 
   @Override
   public void edit(EquellaItemBean itemBean, ItemEditor editor, boolean importing) {
@@ -89,7 +88,8 @@ public class StandardDeserializerEditor implements ItemDeserializerEditor {
     }
     List<AttachmentBean> attachments = itemBean.getAttachments();
     if (attachments != null) {
-      Map<String, AttachmentSerializer> deserializerMap = attachmentDeserializers.getBeanMap();
+      Map<String, AttachmentSerializer> deserializerMap =
+          attachmentDeserializers.getAttachmentSerializers();
       List<String> attachmentUuids = Lists.newArrayList();
       for (AttachmentBean attachmentBean : attachments) {
         EquellaAttachmentBean equellaAttachmentBean = (EquellaAttachmentBean) attachmentBean;

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/legacy/LegacyGuice.java
@@ -30,7 +30,7 @@ import com.tle.core.i18n.service.LanguageService;
 import com.tle.core.institution.InstitutionService;
 import com.tle.core.item.edit.attachment.AbstractAttachmentEditor;
 import com.tle.core.item.helper.ItemHelper;
-import com.tle.core.item.serializer.AttachmentSerializer;
+import com.tle.core.item.serializer.impl.AttachmentSerializerProvider;
 import com.tle.core.item.standard.service.ItemCommentService;
 import com.tle.core.jackson.ObjectMapperService;
 import com.tle.core.oauth.service.OAuthService;
@@ -200,7 +200,7 @@ public class LegacyGuice extends AbstractModule {
 
   @Inject public static EncryptionService encryptionService;
 
-  @Inject public static PluginTracker<AttachmentSerializer> attachmentDeserializers;
+  @Inject public static AttachmentSerializerProvider attachmentSerializerProvider;
 
   @Inject public static PluginTracker<AbstractAttachmentEditor> attachEditorTracker;
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/item/equella/interfaces/beans/CloudAttachmentBean.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/item/equella/interfaces/beans/CloudAttachmentBean.java
@@ -1,9 +1,11 @@
 /*
- * Copyright 2017 Apereo
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/item/equella/interfaces/beans/CloudAttachmentBean.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/item/equella/interfaces/beans/CloudAttachmentBean.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Apereo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tle.web.api.item.equella.interfaces.beans;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class CloudAttachmentBean extends EquellaAttachmentBean {
+
+  private UUID providerId;
+  private String vendorId;
+  private String cloudType;
+  private Map<String, Object> display;
+  private Map<String, Object> meta;
+
+  public UUID getProviderId() {
+    return providerId;
+  }
+
+  public void setProviderId(UUID providerId) {
+    this.providerId = providerId;
+  }
+
+  public String getVendorId() {
+    return vendorId;
+  }
+
+  public void setVendorId(String vendorId) {
+    this.vendorId = vendorId;
+  }
+
+  public String getCloudType() {
+    return cloudType;
+  }
+
+  public void setCloudType(String cloudType) {
+    this.cloudType = cloudType;
+  }
+
+  public Map<String, Object> getDisplay() {
+    return display;
+  }
+
+  public void setDisplay(Map<String, Object> display) {
+    this.display = display;
+  }
+
+  public Map<String, Object> getMeta() {
+    return meta;
+  }
+
+  public void setMeta(Map<String, Object> meta) {
+    this.meta = meta;
+  }
+
+  @Override
+  public String getRawAttachmentType() {
+    return "custom/cloud";
+  }
+}

--- a/autotest/IntegTester/ps/tsrc/cloud.tsx
+++ b/autotest/IntegTester/ps/tsrc/cloud.tsx
@@ -10,12 +10,12 @@ import {
   Toolbar,
   Paper,
   Button,
-  Theme,
-  createMuiTheme,
   CssBaseline
 } from "@material-ui/core";
-import { makeStyles, ThemeProvider } from "@material-ui/styles";
-import { deepOrange, deepPurple } from "@material-ui/core/colors";
+import { ThemeProvider } from "@material-ui/styles";
+import { ProviderRegistrationResponse } from "oeq-cloudproviders/registration";
+import { createRegistration, UpdateRegistration } from "./registration";
+import { theme, useStyles } from "./theme";
 
 interface Props {
   register?: string;
@@ -23,36 +23,6 @@ interface Props {
   name?: string;
   description?: string;
   iconUrl?: string;
-}
-
-interface OAuthCredentials {
-  clientId: string;
-  clientSecret: string;
-}
-
-interface ServiceUri {
-  uri: string;
-  authenticated: boolean;
-}
-
-interface ProviderRegistration {
-  name: string;
-  description?: string;
-  vendorId: String;
-  baseUrl: string;
-  iconUrl?: string;
-  providerAuth: OAuthCredentials;
-  serviceUris: { [key: string]: ServiceUri };
-  viewers: object;
-}
-
-interface ProviderRegistrationInstance extends ProviderRegistration {
-  oeqAuth: OAuthCredentials;
-}
-
-interface ProviderRegistrationResponse {
-  instance: ProviderRegistrationInstance;
-  forwardUrl: string;
 }
 
 interface TokenResponse {
@@ -63,26 +33,6 @@ interface CurrentUserDetails {
   firstName: String;
   lastName: String;
 }
-
-const useStyles = makeStyles((theme: Theme) => {
-  return {
-    content: {
-      display: "flex",
-      flexDirection: "column",
-      flexGrow: 1
-    },
-    root: {
-      height: "100vh",
-      display: "flex",
-      flexDirection: "column"
-    },
-    body: {
-      margin: theme.spacing.unit * 2
-    }
-  };
-});
-
-const baseUrl = "http://localhost:8083/provider/";
 
 function CloudProvider(props: { query: Props }) {
   const q = props.query;
@@ -95,32 +45,11 @@ function CloudProvider(props: { query: Props }) {
   );
 
   async function registerCP(url: string) {
-    const pr: ProviderRegistration = {
+    const pr = createRegistration({
       name: q.name!,
-      description: q.description,
-      iconUrl: q.iconUrl,
-      baseUrl: baseUrl,
-      vendorId: "oeq_autotest",
-      providerAuth: { clientId: q.name!, clientSecret: q.name! },
-      serviceUris: {
-        oauth: { uri: "${baseurl}access_token", authenticated: false },
-        controls: { uri: "${baseurl}controls", authenticated: true },
-        itemNotification: {
-          uri: "${baseurl}itemNotification?uuid=${uuid}&version=${version}",
-          authenticated: true
-        },
-        control_testcontrol: {
-          uri: "${baseurl}control.js",
-          authenticated: false
-        },
-        myService: {
-          uri:
-            "${baseurl}myService?param1=${param1}&param2=${param2}&from=${userid}",
-          authenticated: true
-        }
-      },
-      viewers: {}
-    };
+      description: q.description!,
+      iconUrl: q.iconUrl
+    });
     await axios
       .post<ProviderRegistrationResponse>(url, pr)
       .then(resp => setResponse(resp.data))
@@ -220,16 +149,6 @@ function CloudProvider(props: { query: Props }) {
     </div>
   );
 }
-
-const theme = createMuiTheme({
-  palette: {
-    primary: deepOrange,
-    secondary: deepPurple
-  },
-  typography: {
-    useNextVariants: true
-  }
-});
 
 ReactDOM.render(
   <React.Fragment>

--- a/autotest/IntegTester/ps/tsrc/registration.tsx
+++ b/autotest/IntegTester/ps/tsrc/registration.tsx
@@ -1,0 +1,139 @@
+import * as React from "react";
+import { useState } from "react";
+import {
+  TextField,
+  Button,
+  AppBar,
+  Toolbar,
+  Typography,
+  Paper
+} from "@material-ui/core";
+import { ProviderRegistration } from "oeq-cloudproviders/registration";
+import axios from "axios";
+import { useStyles } from "./theme";
+
+export const serverBase = "http://localhost:8083/";
+export const baseUrl = serverBase + "provider/";
+
+export function UpdateRegistration() {
+  const [institutionUrl, setInstitutionUrl] = useState(
+    "http://doolse-sabre:8080/workflow/"
+  );
+  const [providerId, setProviderId] = useState(
+    "ba87a9bb-0281-4c0d-9397-772ba036e85b"
+  );
+  const [token, setToken] = useState("a63b07f9-204b-4507-87d0-d220d7aade8a");
+  const [name, setName] = useState("Updated provider");
+  const [description, setDescription] = useState("");
+  const classes = useStyles();
+  function update() {
+    axios.put(
+      institutionUrl +
+        "api/cloudprovider/provider/" +
+        encodeURIComponent(providerId),
+      createRegistration({ name, description }),
+      {
+        headers: {
+          "X-Authorization": "access_token=" + token
+        }
+      }
+    );
+  }
+
+  return (
+    <div id="testCloudProvider" className={classes.root}>
+      <AppBar position="static" color="primary">
+        <Toolbar>
+          <Typography variant="h6" color="inherit">
+            Test Cloud Provider
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Paper className={classes.content}>
+        <div className={classes.body}>
+          <div>
+            <TextField
+              label="Institution URL"
+              value={institutionUrl}
+              className={classes.textField}
+              onChange={e => setInstitutionUrl(e.target.value)}
+            />
+            <TextField
+              label="Provider ID"
+              value={providerId}
+              className={classes.textField}
+              onChange={e => setProviderId(e.target.value)}
+            />
+            <TextField
+              label="Token"
+              value={token}
+              className={classes.textField}
+              onChange={e => setToken(e.target.value)}
+            />
+          </div>
+          <div>
+            <TextField
+              label="Name"
+              value={name}
+              className={classes.textField}
+              onChange={e => setName(e.target.value)}
+            />
+            <TextField
+              label="Description"
+              value={description}
+              className={classes.textField}
+              onChange={e => setDescription(e.target.value)}
+            />
+          </div>
+          <Button variant="contained" color="secondary" onClick={_ => update()}>
+            Update details
+          </Button>
+        </div>
+      </Paper>
+    </div>
+  );
+}
+
+export function createRegistration(params: {
+  name: string;
+  description: string;
+  iconUrl?: string;
+}): ProviderRegistration {
+  return {
+    name: params.name,
+    description: params.description,
+    iconUrl: params.iconUrl,
+    baseUrl: baseUrl,
+    vendorId: "oeq_autotest",
+    providerAuth: { clientId: params.name, clientSecret: params.name },
+    serviceUris: {
+      oauth: { uri: "${baseurl}access_token", authenticated: false },
+      controls: { uri: "${baseurl}controls", authenticated: true },
+      itemNotification: {
+        uri: "${baseurl}itemNotification?uuid=${uuid}&version=${version}",
+        authenticated: true
+      },
+      control_testcontrol: {
+        uri: "${baseurl}control.js",
+        authenticated: false
+      },
+      myService: {
+        uri:
+          "${baseurl}myService?param1=${param1}&param2=${param2}&from=${userid}",
+        authenticated: true
+      },
+      viewattachment: {
+        uri:
+          serverBase +
+          "viewitem.html?attachment=${attachment}&item=${item}&version=${version}&viewer=${viewer}",
+        authenticated: true
+      }
+    },
+    viewers: {
+      simple: {
+        "": { name: "Default", serviceId: "viewattachment" },
+        other: { name: "Other viewer", serviceId: "viewattachment" }
+      }
+    }
+  };
+}

--- a/autotest/IntegTester/ps/tsrc/theme.tsx
+++ b/autotest/IntegTester/ps/tsrc/theme.tsx
@@ -1,0 +1,37 @@
+import "babel-polyfill";
+import { Theme, createMuiTheme } from "@material-ui/core";
+import { makeStyles } from "@material-ui/styles";
+import { deepOrange, deepPurple } from "@material-ui/core/colors";
+
+export const theme = createMuiTheme({
+  palette: {
+    primary: deepOrange,
+    secondary: deepPurple
+  },
+  typography: {
+    useNextVariants: true
+  }
+});
+
+export const useStyles = makeStyles((theme: Theme) => {
+  return {
+    content: {
+      display: "flex",
+      flexDirection: "column",
+      flexGrow: 1
+    },
+    root: {
+      height: "100vh",
+      display: "flex",
+      flexDirection: "column"
+    },
+    body: {
+      margin: theme.spacing.unit * 2
+    },
+    textField: {
+      marginLeft: theme.spacing.unit,
+      marginRight: theme.spacing.unit,
+      width: 300
+    }
+  };
+});

--- a/autotest/IntegTester/ps/tsrc/update.tsx
+++ b/autotest/IntegTester/ps/tsrc/update.tsx
@@ -1,0 +1,27 @@
+import * as ReactDOM from "react-dom";
+import * as React from "react";
+import "babel-polyfill";
+import { createMuiTheme, CssBaseline } from "@material-ui/core";
+import { ThemeProvider } from "@material-ui/styles";
+import { deepOrange, deepPurple } from "@material-ui/core/colors";
+import { UpdateRegistration } from "./registration";
+
+const theme = createMuiTheme({
+  palette: {
+    primary: deepOrange,
+    secondary: deepPurple
+  },
+  typography: {
+    useNextVariants: true
+  }
+});
+
+ReactDOM.render(
+  <React.Fragment>
+    <CssBaseline />
+    <ThemeProvider theme={theme}>
+      <UpdateRegistration />
+    </ThemeProvider>
+  </React.Fragment>,
+  document.getElementById("app")
+);

--- a/autotest/IntegTester/ps/tsrc/viewitem.tsx
+++ b/autotest/IntegTester/ps/tsrc/viewitem.tsx
@@ -1,0 +1,36 @@
+import * as ReactDOM from "react-dom";
+import * as React from "react";
+import "babel-polyfill";
+import { parse } from "query-string";
+import { CssBaseline } from "@material-ui/core";
+import { ThemeProvider } from "@material-ui/styles";
+import { theme, useStyles } from "./theme";
+
+interface Props {
+  attachment?: string;
+  item?: string;
+  version?: string;
+}
+
+declare const postValues: Props;
+
+function ViewItem(props: { query: Props }) {
+  const q = props.query;
+  const classes = useStyles();
+
+  return (
+    <div id="testCloudProvider" className={classes.root}>
+      {JSON.stringify(q)}
+    </div>
+  );
+}
+
+ReactDOM.render(
+  <React.Fragment>
+    <CssBaseline />
+    <ThemeProvider theme={theme}>
+      <ViewItem query={postValues} />
+    </ThemeProvider>
+  </React.Fragment>,
+  document.getElementById("app")
+);

--- a/autotest/IntegTester/ps/www/control.tsx
+++ b/autotest/IntegTester/ps/www/control.tsx
@@ -246,6 +246,25 @@ function TestControl(p: ControlApi<MyConfig>) {
                 uploadedDate: new Date()
               },
               xmlPath: rootNode + "/two/uuid"
+            },
+            {
+              command: "addAttachment",
+              attachment: {
+                type: "cloud",
+                description: "This is a cloud attachment",
+                providerId: p.providerId,
+                cloudType: "simple",
+                vendorId: p.vendorId,
+                display: {
+                  Arbitrary: "Field",
+                  Size: 0,
+                  Ordered: true
+                },
+                meta: {
+                  viewer: "Something"
+                }
+              },
+              xmlPath: rootNode + "/one/uuid"
             }
           ]);
         }}

--- a/autotest/IntegTester/ps/www/update.html
+++ b/autotest/IntegTester/ps/www/update.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <title>Test cloud provider</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="../tsrc/update.tsx"></script>
+  </body>
+</html>

--- a/autotest/IntegTester/ps/www/viewitem.html
+++ b/autotest/IntegTester/ps/www/viewitem.html
@@ -1,0 +1,10 @@
+<html>
+  <head>
+    <title>Viewing items for test cloud provider</title>
+    <base href="http://localhost:8083/" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="../tsrc/viewitem.tsx"></script>
+  </body>
+</html>

--- a/autotest/IntegTester/src/main/scala/integtester/testprovider/TestingCloudProvider.scala
+++ b/autotest/IntegTester/src/main/scala/integtester/testprovider/TestingCloudProvider.scala
@@ -102,11 +102,11 @@ class TestingCloudProvider(implicit val cs: ContextShift[IO]) extends Http4sDsl[
                                  None).asJson)
         }
       }
-    case request @ GET -> Root / "control.js" => {
+    case request @ GET -> Root / "control.js" =>
       StaticFile
         .fromResource[IO]("/www/control.js", ExecutionContext.global)
         .getOrElse(Response.notFound)
-    }
+
   }
 
   val middleware: AuthMiddleware[IO, TestUser] =

--- a/cloudprovidersdk/controls/index.d.ts
+++ b/cloudprovidersdk/controls/index.d.ts
@@ -21,7 +21,20 @@ interface YoutubeAttachment extends BaseAttachment {
   uploadedDate: Date;
 }
 
-type Attachment = FileAttachment | UrlAttachment | YoutubeAttachment;
+interface CloudAttachment extends BaseAttachment {
+  type: "cloud";
+  providerId: string;
+  vendorId: string;
+  cloudType: string;
+  display?: object;
+  meta?: object;
+}
+
+type Attachment =
+  | FileAttachment
+  | UrlAttachment
+  | YoutubeAttachment
+  | CloudAttachment;
 
 interface AddAttachment {
   command: "addAttachment";

--- a/cloudprovidersdk/registration/index.d.ts
+++ b/cloudprovidersdk/registration/index.d.ts
@@ -1,0 +1,29 @@
+interface OAuthCredentials {
+  clientId: string;
+  clientSecret: string;
+}
+
+interface ServiceUri {
+  uri: string;
+  authenticated: boolean;
+}
+
+export interface ProviderRegistration {
+  name: string;
+  description?: string;
+  vendorId: String;
+  baseUrl: string;
+  iconUrl?: string;
+  providerAuth: OAuthCredentials;
+  serviceUris: { [key: string]: ServiceUri };
+  viewers: object;
+}
+
+interface ProviderRegistrationInstance extends ProviderRegistration {
+  oeqAuth: OAuthCredentials;
+}
+
+interface ProviderRegistrationResponse {
+  instance: ProviderRegistrationInstance;
+  forwardUrl: string;
+}


### PR DESCRIPTION
* Abstract away from JPF extensions for attachment editing / json conversion (`AttachmentEditorProvider`, `AttachmentSerializerProvider`)
* Create new "serializer" for Cloud attachments  - `CloudAttachmentSerializer`
* Create a new resource extension for viewing attachments - `CloudAttachmentResourceExtension`
* Modify the test cloud provider to create some of these attachments
