### PR TITLE
Fix CodeBuild Issue

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,7 +19,7 @@ phases:
     commands:
       - sbt -no-colors -Dconfig.file=${HOME}/build.conf test installerZip writeLanguagePack writeScriptingJavadoc
       - sbt -mem 2048 -no-colors "project autotest" installEquella startEquella configureInstall setupForTests Tests/test Tests/Serial/test OldTests/test coverageReport
-      - cd import-export-tool && ./gradlew build
+  #      - cd import-export-tool && ./gradlew build
   post_build:
     commands:
       - publishBuildResults

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,8 +18,7 @@ phases:
   build:
     commands:
       - sbt -no-colors -Dconfig.file=${HOME}/build.conf test installerZip writeLanguagePack writeScriptingJavadoc
-      #- sbt -mem 2048 -no-colors "project autotest" installEquella startEquella configureInstall setupForTests Tests/test Tests/Serial/test OldTests/test coverageReport
-      - sbt -mem 2048 -no-colors "project autotest" installEquella startEquella configureInstall setupForTests Tests/test coverageReport
+      - sbt -mem 2048 -no-colors "project autotest" installEquella startEquella configureInstall setupForTests Tests/test Tests/Serial/test OldTests/test coverageReport
       - (cd import-export-tool && ./gradlew build); cd -
   post_build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -18,8 +18,9 @@ phases:
   build:
     commands:
       - sbt -no-colors -Dconfig.file=${HOME}/build.conf test installerZip writeLanguagePack writeScriptingJavadoc
-      - sbt -mem 2048 -no-colors "project autotest" installEquella startEquella configureInstall setupForTests Tests/test Tests/Serial/test OldTests/test coverageReport
-  #      - cd import-export-tool && ./gradlew build
+      #- sbt -mem 2048 -no-colors "project autotest" installEquella startEquella configureInstall setupForTests Tests/test Tests/Serial/test OldTests/test coverageReport
+      - sbt -mem 2048 -no-colors "project autotest" installEquella startEquella configureInstall setupForTests Tests/test coverageReport
+      - cd import-export-tool && ./gradlew build
   post_build:
     commands:
       - publishBuildResults

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,7 +20,7 @@ phases:
       - sbt -no-colors -Dconfig.file=${HOME}/build.conf test installerZip writeLanguagePack writeScriptingJavadoc
       #- sbt -mem 2048 -no-colors "project autotest" installEquella startEquella configureInstall setupForTests Tests/test Tests/Serial/test OldTests/test coverageReport
       - sbt -mem 2048 -no-colors "project autotest" installEquella startEquella configureInstall setupForTests Tests/test coverageReport
-      - cd import-export-tool && ./gradlew build
+      - (cd import-export-tool && ./gradlew build); cd -
   post_build:
     commands:
       - publishBuildResults


### PR DESCRIPTION
Adding the task to build the import/export tools broke the build, as it was failing to find some files it needs to determine version etc.

Simply need to make sure we return the directory before the task, as the `publishBuildResults` assumes that. Seeing we only do one `cd` just went with `cd -`. If it was more involved, we go with `pushd` and `popd`.