### PR TITLE
Slow down Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,7 @@
 {
   "extends": ["config:base"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 1,
   "packageRules": [
     {
       "packagePatterns": ["^com.fasterxml.jackson"],


### PR DESCRIPTION
Finding lots of PRs, and with all the rebasing we've got tons of builds
happening. May also need to consider reconfiguring the rebase process
too.

I think this is how you're meant to do this. I'm following https://renovatebot.com/docs/reconfigure-renovate/