### PR TITLE
Set Hikari logging on build to error state

### DIFF
--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/factory/guice/HibernateFactoryModule.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/factory/guice/HibernateFactoryModule.java
@@ -21,8 +21,6 @@ package com.tle.core.hibernate.factory.guice;
 import com.tle.core.config.guice.PropertiesModule;
 import com.tle.core.hibernate.ExtendedDialect;
 import com.tle.core.hibernate.type.ImmutableHibernateXStreamType;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
 
 @SuppressWarnings("nls")
 public class HibernateFactoryModule extends PropertiesModule {
@@ -39,9 +37,5 @@ public class HibernateFactoryModule extends PropertiesModule {
     bindProp("hibernate.connection.username");
     bindProp("hibernate.connection.password");
     bindProp("hibernate.connection.url");
-  }
-
-  static {
-    Logger.getLogger("com.zaxxer.hikari.pool.ProxyConnection").setLevel(Level.ERROR);
   }
 }

--- a/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/factory/guice/HibernateFactoryModule.java
+++ b/Source/Plugins/Core/com.equella.serverbase/src/com/tle/core/hibernate/factory/guice/HibernateFactoryModule.java
@@ -21,6 +21,8 @@ package com.tle.core.hibernate.factory.guice;
 import com.tle.core.config.guice.PropertiesModule;
 import com.tle.core.hibernate.ExtendedDialect;
 import com.tle.core.hibernate.type.ImmutableHibernateXStreamType;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 
 @SuppressWarnings("nls")
 public class HibernateFactoryModule extends PropertiesModule {
@@ -37,5 +39,9 @@ public class HibernateFactoryModule extends PropertiesModule {
     bindProp("hibernate.connection.username");
     bindProp("hibernate.connection.password");
     bindProp("hibernate.connection.url");
+  }
+
+  static {
+    Logger.getLogger("com.zaxxer.hikari.pool.ProxyConnection").setLevel(Level.ERROR);
   }
 }

--- a/Source/Server/equellaserver/src/com/tle/core/equella/runner/EQUELLAServer.java
+++ b/Source/Server/equellaserver/src/com/tle/core/equella/runner/EQUELLAServer.java
@@ -32,6 +32,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 import org.apache.log4j.PropertyConfigurator;
 import org.java.plugin.ObjectFactory;
 import org.java.plugin.Plugin;
@@ -98,7 +100,7 @@ public class EQUELLAServer {
         // Do not stop - But unable to delete equella.lock
       }
     }
-
+    Logger.getLogger("com.zaxxer.hikari.pool.ProxyConnection").setLevel(Level.ERROR);
     PropertyConfigurator.configure(loader.getResource("learningedge-log4j.properties"));
     Properties mandatory = new Properties();
     Properties optional = new Properties();


### PR DESCRIPTION
An unimportant warning from Hikari that was previously displayed as a 
single line is now filling the build logs with stack traces since updating 
it in #918. After doing some digging it was determined that this 
warning is of no consequence, it is simply the postgres driver 
determining what it can and cannot do, and can therefore be safely 
suppressed.