### PR TITLE
Allow new UI in IE11 to change CSS

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/css/ie11compat.css
+++ b/Source/Plugins/Core/com.equella.core/resources/web/css/ie11compat.css
@@ -1,0 +1,4 @@
+.material-icons {
+  /* Support for IE */
+  font-feature-settings: "liga";
+}

--- a/Source/Plugins/Core/com.equella.core/resources/web/css/styles.css
+++ b/Source/Plugins/Core/com.equella.core/resources/web/css/styles.css
@@ -9,11 +9,6 @@
   font-style: normal;
 }
 
-.material-icons {
-  /* Support for IE */
-  font-feature-settings: "liga";
-}
-
 /*****************************************************************************
  CSS Reset (excluding img since width and height style override image attributes)
 *****************************************************************************/

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -57,7 +57,6 @@ object RenderNewTemplate {
         s"api/language/bundle/${LocaleLookup.selectLocale.getLocale.toLanguageTag}/bundle.js")
         .preRender(info)
       new IncludeFile(s"api/theme/theme.js").preRender(info)
-      RenderTemplate.STYLES_CSS.preRender(info)
     }
   }
 
@@ -150,6 +149,7 @@ object RenderNewTemplate {
       RenderTemplate.TINYMCE_CONTENT_CSS.preRender(context)
       RenderTemplate.TINYMCE_CONTENT_MIN_CSS.preRender(context)
       RenderTemplate.TINYMCE_SKIN_CSS.preRender(context)
+      RenderTemplate.IE11_COMPAT_CSS.preRender(context)
     }
   }
 

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -57,6 +57,7 @@ object RenderNewTemplate {
         s"api/language/bundle/${LocaleLookup.selectLocale.getLocale.toLanguageTag}/bundle.js")
         .preRender(info)
       new IncludeFile(s"api/theme/theme.js").preRender(info)
+      RenderTemplate.STYLES_CSS.preRender(info)
     }
   }
 

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -147,6 +147,9 @@ object RenderNewTemplate {
     if (Option(context.getRequest.getHeader("User-Agent")).exists(_.contains("Trident"))) {
       context.addJs(
         "https://polyfill.io/v3/polyfill.min.js?features=es6%2CURL%2CElement%2CArray.prototype.forEach%2Cdocument.querySelector%2CNodeList.prototype.forEach%2CNodeList.prototype.%40%40iterator%2CNode.prototype.contains")
+      RenderTemplate.TINYMCE_CONTENT_CSS.preRender(context)
+      RenderTemplate.TINYMCE_CONTENT_MIN_CSS.preRender(context)
+      RenderTemplate.TINYMCE_SKIN_CSS.preRender(context)
     }
   }
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/RenderTemplate.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/RenderTemplate.java
@@ -92,6 +92,22 @@ public class RenderTemplate extends AbstractPrototypeSection<RenderTemplate.Rend
           .hasRtl()
           .priority(Priority.LOWEST)
           .make();
+  public static final CssInclude TINYMCE_SKIN_CSS =
+      include(RESOURCES.url("reactjs/tinymce/skins/ui/oxide/skin.css"))
+          .prerender(BOOTSTRAP_CSS)
+          .hasRtl()
+          .priority(Priority.LOWEST)
+          .make();
+  public static final CssInclude TINYMCE_CONTENT_CSS =
+      include(RESOURCES.url("reactjs/tinymce/skins/ui/oxide/content.css"))
+          .hasRtl()
+          .priority(Priority.LOWEST)
+          .make();
+  public static final CssInclude TINYMCE_CONTENT_MIN_CSS =
+      include(RESOURCES.url("reactjs/tinymce/skins/ui/oxide/content.min.css"))
+          .hasRtl()
+          .priority(Priority.LOWEST)
+          .make();
   public static final CssInclude CUSTOMER_CSS =
       include("css/customer.css").priority(Priority.HIGHEST).make();
 

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/RenderTemplate.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/template/RenderTemplate.java
@@ -92,6 +92,12 @@ public class RenderTemplate extends AbstractPrototypeSection<RenderTemplate.Rend
           .hasRtl()
           .priority(Priority.LOWEST)
           .make();
+  public static final CssInclude IE11_COMPAT_CSS =
+      include(RESOURCES.url("css/ie11compat.css"))
+          .prerender(BOOTSTRAP_CSS)
+          .hasRtl()
+          .priority(Priority.LOWEST)
+          .make();
   public static final CssInclude TINYMCE_SKIN_CSS =
       include(RESOURCES.url("reactjs/tinymce/skins/ui/oxide/skin.css"))
           .prerender(BOOTSTRAP_CSS)


### PR DESCRIPTION
Resolves an issue in which switching to "Videos" or "Images" in the search tab would break the styles upon moving back to "Standard" ( which looked like this)
![image](https://user-images.githubusercontent.com/24543345/58141797-f25b2700-7c87-11e9-8dcb-9eafba54a429.png)
Now working as intended.
![image](https://user-images.githubusercontent.com/24543345/58141891-4f56dd00-7c88-11e9-97ea-dbf38fef05f9.png)
Also fixed an issue in which the menu icons would not render in IE11.
Also fixed an issue which would prevent the login notice editor from rendering in IE11.