### PR TITLE
Stop aligned images from falling off the end of the login notice

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/view/logon/logon.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/logon/logon.ftl
@@ -38,7 +38,7 @@
 	</#list>
 </div>
 <#if m.loginNotice??>
-  <div class="area">
+  <div class="area" style="overflow: hidden">
     <div id="loginNotice" class="loginnotice">
       ${m.loginNotice}
     </div>


### PR DESCRIPTION
When images are aligned in a login notice, they use the float:left or float:right styles. Without overflow being hidden, this makes the image fall off the end of the login notice section. Hiding it forces the images to be in the correct place.