### PR TITLE
Rework login dialog to display messages properly

### DIFF
--- a/Source/Plugins/Admin/com.tle.webstart.admin/src/com/tle/admin/boot/Bootstrap.java
+++ b/Source/Plugins/Admin/com.tle.webstart.admin/src/com/tle/admin/boot/Bootstrap.java
@@ -130,28 +130,24 @@ public final class Bootstrap {
         String password = System.getProperty(PASSWORD_PARAMETER);
 
         LoginDialog loginDialog = new LoginDialog();
-        boolean retry = false;
         try {
           if (username != null && password != null) {
             if (tryLogin(endpointUrl, username, password)) {
               return true;
             }
-            retry = true;
           }
 
           while (true) {
             loginDialog.setUsername(username);
             loginDialog.setVisible(true);
-            if (retry) {
-              loginDialog.setErrorMessage("Invalid credentials");
-            }
             if (loginDialog.getResult() == LoginDialog.RESULT_OK) {
               username = loginDialog.getUsername();
               password = loginDialog.getPassword();
               if (tryLogin(endpointUrl, username, password)) {
                 return true;
+              } else {
+                loginDialog.setErrorMessage("Your credentials are invalid.");
               }
-              retry = true;
             } else {
               return false;
             }

--- a/Source/Plugins/Admin/com.tle.webstart.admin/src/com/tle/admin/boot/LoginDialog.java
+++ b/Source/Plugins/Admin/com.tle.webstart.admin/src/com/tle/admin/boot/LoginDialog.java
@@ -111,7 +111,7 @@ public class LoginDialog extends JDialog implements ActionListener, WindowListen
   }
 
   public void setErrorMessage(String errorMessage) {
-    message.setText(errorMessage);
+    message.setText("<html><b><font color='red'>" + errorMessage + "</font></b></html>");
     if (errorMessage != null) {
       message.setVisible(true);
     }


### PR DESCRIPTION
* Fix the bug that when users  type wrong credentials they can't see any error messages until they try a second time.

* The error message is highlighted in red and bold.