### PR TITLE
IE11 fixes

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -322,7 +322,8 @@ function updateStylesheets(
 
 function deleteElements(elements: { [url: string]: HTMLElement }) {
   for (const key in elements) {
-    elements[key].remove();
+    var e = elements[key];
+    e.parentElement!.removeChild(e);
   }
 }
 

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
@@ -24,7 +24,8 @@ import { oeqTheme } from "../theme";
 
 declare const bridge: Bridge;
 
-const baseFullPath = new URL(document.head.baseURI).pathname;
+const baseFullPath = new URL(document.head.getElementsByTagName("base")[0].href)
+  .pathname;
 const basePath = baseFullPath.substr(0, baseFullPath.length - 1);
 
 declare const renderData:

--- a/Source/Plugins/Core/com.equella.core/resources/view/layouts/outer/react.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/layouts/outer/react.ftl
@@ -20,6 +20,6 @@
     	<script type="text/javascript">
       	var renderData = ${m.renderJs};
     	</script>
-    	${m.body}
     </head>
+    ${m.body}
 </html>

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -119,7 +119,6 @@ object RenderNewTemplate {
                               "text/css",
                               "href",
                               s.getHref(src))
-              writer.endTag("link")
             }
         }
       })


### PR DESCRIPTION
* remove() isn't supported on IE11
* IE complains about extraneous </link> tags and invalid html (as it should)
* use <base> tag instead of baseURI
