### PR TITLE
fix-etag-missing-from-unstable

### DIFF
--- a/Source/Plugins/Admin/com.tle.web.adminconsole/plugin-jpf.xml
+++ b/Source/Plugins/Admin/com.tle.web.adminconsole/plugin-jpf.xml
@@ -2,6 +2,9 @@
 <!DOCTYPE plugin PUBLIC "-//JPF//Java Plug-in Manifest 1.0"
   "http://jpf.sourceforge.net/plugin_1_0.dtd">
 <plugin id="com.tle.web.adminconsole" version="1">
+  <attributes>
+    <attribute id="unpack" value="true" />
+  </attributes>
   <requires>
     <import plugin-id="com.tle.common.i18n"/>
     <import plugin-id="com.tle.core.guice"/>


### PR DESCRIPTION
The reason why last fix was not working is because on Unstable, the way to access adminconsole.jar is different. Locally, the downloading request URL directly points to this file, however on Unstable, the URL points to another file (com.tle.web.adminconsole@1.0.0.jar) , which  results in different methods handling the URL. Thus, the way to calculate ETag is different, which causes the 400 HTTP response code.

After discussing with Jolse,  the best solution is to add the attribute of unpack in the corresponding JPF file. This helps extract the adminconsole.jar from  com.tle.web.adminconsole@1.0.0.jar and then adminconsole.jar is directly accessible. 

To test it, I closed Intellij, and started Equella by running those sbt commands, which are exactly what is done on Unstable. And the result is good.