### PR TITLE
More fixes for IE11 compatibility

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/web/css/ie11compat.css
+++ b/Source/Plugins/Core/com.equella.core/resources/web/css/ie11compat.css
@@ -2,3 +2,6 @@
   /* Support for IE */
   font-feature-settings: "liga";
 }
+input[disabled="disabled"] {
+  position: absolute;
+}

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/cloudprovider/CloudProviderApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/cloudprovider/CloudProviderApi.scala
@@ -19,6 +19,7 @@
 package com.tle.web.api.cloudprovider
 
 import java.util.UUID
+
 import cats.syntax.functor._
 import com.tle.core.cloudproviders._
 import com.tle.core.db._
@@ -31,9 +32,10 @@ import io.lemonlabs.uri.parsing.UrlParser
 import io.swagger.annotations.{Api, ApiOperation}
 import javax.ws.rs._
 import javax.ws.rs.core._
+import org.jboss.resteasy.annotations.cache.NoCache
 
 case class CloudProviderForward(url: String)
-
+@NoCache
 @Api("Cloud Providers")
 @Path("cloudprovider")
 @Produces(value = Array(MediaType.APPLICATION_JSON))

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/template/RenderNewTemplate.scala
@@ -144,7 +144,7 @@ object RenderNewTemplate {
   def supportIEPolyFills(context: PreRenderContext): Unit = {
     if (Option(context.getRequest.getHeader("User-Agent")).exists(_.contains("Trident"))) {
       context.addJs(
-        "https://polyfill.io/v3/polyfill.min.js?features=es6%2CURL%2CElement%2CArray.prototype.forEach%2Cdocument.querySelector%2CNodeList.prototype.forEach%2CNodeList.prototype.%40%40iterator%2CNode.prototype.contains")
+        "https://polyfill.io/v3/polyfill.min.js?features=es6%2CURL%2CElement%2CArray.prototype.forEach%2Cdocument.querySelector%2CNodeList.prototype.forEach%2CNodeList.prototype.%40%40iterator%2CNode.prototype.contains%2CString.prototype.includes%2CArray.prototype.includes")
       RenderTemplate.TINYMCE_CONTENT_CSS.preRender(context)
       RenderTemplate.TINYMCE_CONTENT_MIN_CSS.preRender(context)
       RenderTemplate.TINYMCE_SKIN_CSS.preRender(context)

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/activation/CourseResource.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/api/activation/CourseResource.java
@@ -30,7 +30,9 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import org.jboss.resteasy.annotations.cache.NoCache;
 
+@NoCache
 @Path("course")
 @Api(value = "Courses", description = "course")
 @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
- [x] Stop the search bar on the search page from stretching across the screen and rendering the search button unclickable

- [x]  Add polyfills for Array.prototype.includes and String.prototype.includes to fix the course editor

- [x] Disable caching on cloud provider and course API REST calls - most browsers don't cache these anyway, but IE11 likes to be difficult.
