### PR TITLE
Change to openjdk and remove Ubuntu dist for travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: scala
-dist: trusty
 cache:
   directories:
     - "$HOME/.ivy2"
     - "$HOME/.cache"
     - "$HOME/.sbt"
 jdk:
-  - oraclejdk8
+  - openjdk8
 before_install:
   - nvm install $NODE_JS_VERSION
   - node --version


### PR DESCRIPTION
On develop branch, change JDK used in Travis build to openjdk8, and remove the specified Ubuntu dist.