### PR TITLE
IE11 Compatibility: Disable caching on UI API requests

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/SettingsResource.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/settings/SettingsResource.scala
@@ -27,6 +27,7 @@ import com.tle.core.settings.SettingsDB
 import com.tle.web.settings.{EditableSettings, SettingsList, UISettings}
 import io.swagger.annotations.Api
 import javax.ws.rs.{GET, PUT, Path, Produces}
+import org.jboss.resteasy.annotations.cache.NoCache
 
 case class SettingTypeLinks(web: Option[URI], rest: Option[URI], route: Option[String])
 case class SettingType(id: String,
@@ -44,7 +45,7 @@ object SettingTypeLinks {
                        if (ed.isRoute) Some("/" + ed.uri) else None)
   }
 }
-
+@NoCache
 @Path("settings/")
 @Produces(value = Array("application/json"))
 @Api(value = "Settings")


### PR DESCRIPTION
Fixes an IE11 issue in which the UI switcher in the settings menu wouldn't show the correct switched state. Due to IE11 caching a GET request.