### PR TITLE
Add freetext analyzer config to upgrader

### DIFF
--- a/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/UpgradeMain.java
+++ b/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/UpgradeMain.java
@@ -27,6 +27,7 @@ import com.tle.common.Check;
 import com.tle.common.util.ExecUtils;
 import com.tle.upgrade.UpgradeLog.LogStatus;
 import com.tle.upgrade.upgraders.AddExifToolConfg;
+import com.tle.upgrade.upgraders.AddFreetextAnalyzerConfig;
 import com.tle.upgrade.upgraders.AddLDAPPoolingOptions;
 import com.tle.upgrade.upgraders.AddLibAvConfig;
 import com.tle.upgrade.upgraders.AddNonHttpOnly;
@@ -113,7 +114,8 @@ public class UpgradeMain {
         new UpdateLog4jConfigForTomcatLog(),
         new ConvertBoneCPtoHikariCP(),
         new AddLDAPPoolingOptions(),
-        new AddLibAvConfig()
+        new AddLibAvConfig(),
+        new AddFreetextAnalyzerConfig()
       };
 
   public static void main(String[] args) throws Throwable {

--- a/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/upgraders/AddFreetextAnalyzerConfig.java
+++ b/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/upgraders/AddFreetextAnalyzerConfig.java
@@ -1,0 +1,55 @@
+package com.tle.upgrade.upgraders;
+
+import com.dytech.edge.common.Constants;
+import com.google.common.collect.Lists;
+import com.tle.common.util.EquellaConfig;
+import com.tle.upgrade.LineFileModifier;
+import com.tle.upgrade.PropertyFileModifier;
+import com.tle.upgrade.UpgradeResult;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+public class AddFreetextAnalyzerConfig extends AbstractUpgrader {
+  @Override
+  public String getId() {
+    return "AddFreetextAnalyzerConfig";
+  }
+
+  @Override
+  public boolean isBackwardsCompatible() {
+    return false;
+  }
+
+  @Override
+  public void upgrade(UpgradeResult result, File tleInstallDir) throws Exception {
+    EquellaConfig config = new EquellaConfig(tleInstallDir);
+
+    result.addLogMessage("Updating optional-config properties");
+    updateOptionalProperties(result, config.getConfigDir());
+  }
+
+  private void updateOptionalProperties(final UpgradeResult result, File configDir) {
+    try {
+      LineFileModifier lineMod =
+          new LineFileModifier(new File(configDir, PropertyFileModifier.OPTIONAL_CONFIG), result) {
+            @Override
+            protected String processLine(String line) {
+              // Do nothing
+              return line;
+            }
+
+            @Override
+            protected List<String> addLines() {
+              String libavComment = "# Uncomment and specify the stemming language";
+              String libavProp = "#freetext.analyzer.language = en";
+              return Lists.newArrayList(Constants.BLANK, libavComment, libavProp);
+            }
+          };
+
+      lineMod.update();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to update config file", e);
+    }
+  }
+}

--- a/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/upgraders/AddFreetextAnalyzerConfig.java
+++ b/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/upgraders/AddFreetextAnalyzerConfig.java
@@ -43,7 +43,7 @@ public class AddFreetextAnalyzerConfig extends AbstractUpgrader {
   public void upgrade(UpgradeResult result, File tleInstallDir) throws Exception {
     EquellaConfig config = new EquellaConfig(tleInstallDir);
 
-    result.addLogMessage("Updating optional-config properties");
+    result.addLogMessage("Updating optional freetext index properties");
     updateOptionalProperties(result, config.getConfigDir());
   }
 
@@ -59,9 +59,9 @@ public class AddFreetextAnalyzerConfig extends AbstractUpgrader {
 
             @Override
             protected List<String> addLines() {
-              String libavComment = "# Uncomment and specify the stemming language";
-              String libavProp = "#freetext.analyzer.language = en";
-              return Lists.newArrayList(Constants.BLANK, libavComment, libavProp);
+              String freetextComment = "# Uncomment and specify the stemming language";
+              String freetextProp = "#freetext.analyzer.language = en";
+              return Lists.newArrayList(Constants.BLANK, freetextComment, freetextProp);
             }
           };
 

--- a/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/upgraders/AddFreetextAnalyzerConfig.java
+++ b/Source/Tools/UpgradeInstallation/src/com/tle/upgrade/upgraders/AddFreetextAnalyzerConfig.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to The Apereo Foundation under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * The Apereo Foundation licenses this file to you under the Apache License,
+ * Version 2.0, (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tle.upgrade.upgraders;
 
 import com.dytech.edge.common.Constants;


### PR DESCRIPTION
This PR aims to fix the issue that tle_upgrader does not include the language analyzer property in optional-config.properties. By fixing this, our clients can upgrade oEQ by using the tle_upgrader and use the new feature of  the language analyzer.

This issue was found by Charlie and tested by him as well. 