### PR TITLE
Cloud provider breaking changes

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/package-lock.json
+++ b/Source/Plugins/Core/com.equella.core/js/package-lock.json
@@ -6191,8 +6191,8 @@
       }
     },
     "oeq-cloudproviders": {
-      "version": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3",
-      "from": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3"
+      "version": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#32d958ddfff64ca748e7e1b2eae0f0487946a487",
+      "from": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#32d958ddfff64ca748e7e1b2eae0f0487946a487"
     },
     "on-finished": {
       "version": "2.3.0",

--- a/Source/Plugins/Core/com.equella.core/js/package-lock.json
+++ b/Source/Plugins/Core/com.equella.core/js/package-lock.json
@@ -6191,8 +6191,8 @@
       }
     },
     "oeq-cloudproviders": {
-      "version": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#f693a3aa1aa4d1f59150b94a13e6084b499ef582",
-      "from": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#f693a3aa1aa4d1f59150b94a13e6084b499ef582"
+      "version": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3",
+      "from": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3"
     },
     "on-finished": {
       "version": "2.3.0",

--- a/Source/Plugins/Core/com.equella.core/js/package.json
+++ b/Source/Plugins/Core/com.equella.core/js/package.json
@@ -38,7 +38,7 @@
     "jspolyfill-array.prototype.find": "0.1.3",
     "luxon": "1.11.4",
     "material-ui-pickers": "2.2.4",
-    "oeq-cloudproviders": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3",
+    "oeq-cloudproviders": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#32d958ddfff64ca748e7e1b2eae0f0487946a487",
     "parcel-bundler": "1.12.1",
     "prop-types": "15.7.2",
     "react": "16.8.6",

--- a/Source/Plugins/Core/com.equella.core/js/package.json
+++ b/Source/Plugins/Core/com.equella.core/js/package.json
@@ -38,7 +38,7 @@
     "jspolyfill-array.prototype.find": "0.1.3",
     "luxon": "1.11.4",
     "material-ui-pickers": "2.2.4",
-    "oeq-cloudproviders": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#f693a3aa1aa4d1f59150b94a13e6084b499ef582",
+    "oeq-cloudproviders": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3",
     "parcel-bundler": "1.12.1",
     "prop-types": "15.7.2",
     "react": "16.8.6",

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentResourceExtension.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudAttachmentResourceExtension.scala
@@ -106,10 +106,10 @@ case class CloudAttachmentViewableResource(info: SectionInfo,
     viewerMap(provider).flatMap(_.get(viewerId))
 
   def serviceUriForViewer(provider: CloudProviderInstance,
-                          viewerId: String): Option[(Viewer, ServiceUri)] =
+                          viewerId: String): Option[(Viewer, ServiceUrl)] =
     for {
       viewer     <- viewerForId(provider, viewerId)
-      serviceUri <- provider.serviceUris.get(viewer.serviceId)
+      serviceUri <- provider.serviceUrls.get(viewer.serviceId)
     } yield (viewer, serviceUri)
 
   def uriParameters: Map[String, Any] = {

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderDB.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/CloudProviderDB.scala
@@ -46,15 +46,15 @@ case class CloudProviderData(baseUrl: String,
                              vendorId: String,
                              providerAuth: CloudOAuthCredentials,
                              oeqAuth: CloudOAuthCredentials,
-                             serviceUris: Map[String, ServiceUri],
+                             serviceUrls: Map[String, ServiceUrl],
                              viewers: Map[String, Map[String, Viewer]])
 
 object CloudProviderData {
 
   implicit val decoderV = deriveDecoder[Viewer]
   implicit val encoderV = deriveEncoder[Viewer]
-  implicit val decoderS = deriveDecoder[ServiceUri]
-  implicit val encoderS = deriveEncoder[ServiceUri]
+  implicit val decoderS = deriveDecoder[ServiceUrl]
+  implicit val encoderS = deriveEncoder[ServiceUrl]
   implicit val decoderC = deriveDecoder[CloudOAuthCredentials]
   implicit val encoderC = deriveEncoder[CloudOAuthCredentials]
 
@@ -98,7 +98,7 @@ object CloudProviderDB {
       iconUrl = data.iconUrl,
       providerAuth = data.providerAuth,
       oeqAuth = data.oeqAuth,
-      serviceUris = data.serviceUris,
+      serviceUrls = data.serviceUrls,
       viewers = data.viewers
     )
   }
@@ -122,7 +122,7 @@ object CloudProviderDB {
           vendorId = reg.vendorId,
           providerAuth = reg.providerAuth,
           oeqAuth = oeqAuth,
-          serviceUris = reg.serviceUris,
+          serviceUrls = reg.serviceUrls,
           viewers = reg.viewers
         )
         CloudProviderDB(newOeq, data)
@@ -176,7 +176,7 @@ object CloudProviderDB {
     for {
       oeqProvider <- EntityDB.readOne(id)
       provider = toInstance(oeqProvider)
-      refreshService <- OptionT.fromOption[DB](provider.serviceUris.get(RefreshServiceId))
+      refreshService <- OptionT.fromOption[DB](provider.serviceUrls.get(RefreshServiceId))
       validated <- OptionT {
         CloudProviderService
           .serviceRequest(refreshService,
@@ -221,7 +221,7 @@ object CloudProviderDB {
         description = oeq.description,
         vendorId = cp.data.vendorId,
         iconUrl = cp.data.iconUrl,
-        canRefresh = DebugSettings.isDevMode && cp.data.serviceUris.contains(RefreshServiceId)
+        canRefresh = DebugSettings.isDevMode && cp.data.serviceUrls.contains(RefreshServiceId)
       )
     }
   }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/UriTemplateService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/UriTemplateService.scala
@@ -71,8 +71,8 @@ object UriTemplateService {
               case Text(t) => CollectTemplate(t :: raw, args, Some(uriTemplate))
               case Replacement(v) =>
                 val replaceValue = v match {
-                  case "baseurl" => baseurl
-                  case o         => variables.get(v).getOrElse(None)
+                  case "baseUrl" => baseurl
+                  case o         => variables.getOrElse(v, None)
                 }
                 CollectTemplate(maybeBlank(raw, last), replaceValue :: args, Some(uriTemplate))
             }

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/package.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/cloudproviders/package.scala
@@ -44,10 +44,10 @@ package object cloudproviders {
     implicit val decodeViewer: Decoder[Viewer] = deriveDecoder
   }
 
-  case class ServiceUri(uri: String, authenticated: Boolean)
+  case class ServiceUrl(url: String, authenticated: Boolean)
 
-  object ServiceUri {
-    implicit val decodeServiceUri: Decoder[ServiceUri] = deriveDecoder
+  object ServiceUrl {
+    implicit val decodeServiceUri: Decoder[ServiceUrl] = deriveDecoder
   }
 
   case class CloudProviderRegistration(name: String,
@@ -56,7 +56,7 @@ package object cloudproviders {
                                        baseUrl: String,
                                        iconUrl: Option[String],
                                        providerAuth: CloudOAuthCredentials,
-                                       serviceUris: Map[String, ServiceUri],
+                                       serviceUrls: Map[String, ServiceUrl],
                                        viewers: Map[String, Map[String, Viewer]])
 
   case class CloudProviderRegistrationResponse(instance: CloudProviderInstance, forwardUrl: String)
@@ -69,7 +69,7 @@ package object cloudproviders {
                                    iconUrl: Option[String],
                                    providerAuth: CloudOAuthCredentials,
                                    oeqAuth: CloudOAuthCredentials,
-                                   serviceUris: Map[String, ServiceUri],
+                                   serviceUrls: Map[String, ServiceUrl],
                                    viewers: Map[String, Map[String, Viewer]])
 
   case class CloudProviderDetails(id: UUID,

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/oauthclient/OAuthClientService.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/core/oauthclient/OAuthClientService.scala
@@ -107,11 +107,10 @@ object OAuthClientService {
       }
 
     def requestTokenAndSave(token: TokenRequest): DB[OAuthTokenState] = {
-      val postRequest = sttp
+      val postRequest = sttp.auth
+        .basic(token.clientId, token.clientSecret)
         .body(
-          OAuthWebConstants.PARAM_GRANT_TYPE    -> OAuthWebConstants.GRANT_TYPE_CREDENTIALS,
-          OAuthWebConstants.PARAM_CLIENT_ID     -> token.clientId,
-          OAuthWebConstants.PARAM_CLIENT_SECRET -> token.clientSecret
+          OAuthWebConstants.PARAM_GRANT_TYPE -> OAuthWebConstants.GRANT_TYPE_CREDENTIALS
         )
         .response(asJson[OAuthTokenResponse])
         .post(uri"${token.authTokenUrl}")

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
@@ -181,7 +181,7 @@ class WizardApi {
       .execute {
         (for {
           cp         <- CloudProviderDB.get(providerId)
-          serviceUri <- OptionT.fromOption[DB](cp.serviceUris.get(serviceId))
+          serviceUri <- OptionT.fromOption[DB](cp.serviceUrls.get(serviceId))
           response <- OptionT.liftF(
             CloudProviderService.serviceRequest(
               serviceUri,
@@ -250,7 +250,7 @@ case class NotifyProvider(providerId: UUID) extends DuringSaveOperation with Ser
     override def execute(): Boolean = RunWithDB.executeWithHibernate {
       (for {
         cp         <- CloudProviderDB.get(providerId)
-        serviceUri <- OptionT.fromOption[DB](cp.serviceUris.get("itemNotification"))
+        serviceUri <- OptionT.fromOption[DB](cp.serviceUrls.get("itemNotification"))
         notifyParams = Map("uuid" -> getItem.getUuid, "version" -> getItem.getVersion.toString)
         _ <- OptionT.liftF(
           CloudProviderService.serviceRequest(serviceUri, cp, notifyParams, sttp.post))

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
@@ -25,12 +25,8 @@ import java.util.UUID
 
 import cats.data.OptionT
 import cats.effect.IO
-import com.dytech.devlib.PropBagEx
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type
-import com.fasterxml.jackson.annotation.JsonTypeInfo.Id
-import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 import com.softwaremill.sttp._
-import com.tle.beans.item.{Item, ItemEditingException, ItemPack}
+import com.tle.beans.item.{Item, ItemPack}
 import com.tle.common.filesystem.FileEntry
 import com.tle.core.cloudproviders.{CloudProviderDB, CloudProviderService}
 import com.tle.core.db.{DB, RunWithDB}
@@ -38,26 +34,17 @@ import com.tle.core.httpclient._
 import com.tle.core.item.operations.{ItemOperationParams, WorkflowOperation}
 import com.tle.core.item.standard.operations.DuringSaveOperation
 import com.tle.legacy.LegacyGuice
-import com.tle.web.api.item.{
-  AddAttachment,
-  AddAttachmentResponse,
-  DeleteAttachment,
-  DeleteAttachmentResponse,
-  EditAttachment,
-  EditAttachmentResponse,
-  ItemEditResponses,
-  ItemEdits
-}
 import com.tle.web.api.item.equella.interfaces.beans.EquellaAttachmentBean
+import com.tle.web.api.item.{ItemEditResponses, ItemEdits}
 import com.tle.web.wizard.impl.WizardServiceImpl.WizardSessionState
 import com.tle.web.wizard.{WizardState, WizardStateInterface}
 import fs2.Stream
 import fs2.io._
 import io.swagger.annotations.Api
 import javax.servlet.http.HttpServletRequest
+import javax.ws.rs._
 import javax.ws.rs.core.Response.{ResponseBuilder, Status}
 import javax.ws.rs.core.{Context, Response, StreamingOutput, UriInfo}
-import javax.ws.rs._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits

--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/cloudproviders/CloudWizardControl.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/cloudproviders/CloudWizardControl.scala
@@ -98,7 +98,7 @@ object CloudWizardControl {
         RunWithDB.execute {
           (for {
             provider   <- CloudProviderDB.get(providerId)
-            serviceUri <- OptionT.fromOption[DB](provider.serviceUris.get(s"control_$controlId"))
+            serviceUri <- OptionT.fromOption[DB](provider.serviceUrls.get(s"control_$controlId"))
             uri <- OptionT(
               CloudProviderService.serviceUri(provider, serviceUri, Map.empty).map(_.toOption))
           } yield new CloudWizardControl(uri, controlDef, provider, controlId))

--- a/autotest/IntegTester/ps/package-lock.json
+++ b/autotest/IntegTester/ps/package-lock.json
@@ -6330,8 +6330,8 @@
       }
     },
     "oeq-cloudproviders": {
-      "version": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3",
-      "from": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3"
+      "version": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#32d958ddfff64ca748e7e1b2eae0f0487946a487",
+      "from": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#32d958ddfff64ca748e7e1b2eae0f0487946a487"
     },
     "on-finished": {
       "version": "2.3.0",

--- a/autotest/IntegTester/ps/package-lock.json
+++ b/autotest/IntegTester/ps/package-lock.json
@@ -6330,8 +6330,8 @@
       }
     },
     "oeq-cloudproviders": {
-      "version": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#85fc56bd8c8717f0b9c12db75475855f1cd38e25",
-      "from": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git"
+      "version": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3",
+      "from": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3"
     },
     "on-finished": {
       "version": "2.3.0",

--- a/autotest/IntegTester/ps/package.json
+++ b/autotest/IntegTester/ps/package.json
@@ -13,7 +13,7 @@
     "babel-polyfill": "6.26.0",
     "js-md5": "0.7.3",
     "jss": "10.0.0-alpha.14",
-    "oeq-cloudproviders": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git",
+    "oeq-cloudproviders": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3",
     "query-string": "6.4.0",
     "react": "16.8.4",
     "react-dom": "16.8.4"

--- a/autotest/IntegTester/ps/package.json
+++ b/autotest/IntegTester/ps/package.json
@@ -13,7 +13,7 @@
     "babel-polyfill": "6.26.0",
     "js-md5": "0.7.3",
     "jss": "10.0.0-alpha.14",
-    "oeq-cloudproviders": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#20b0109089838f8d7029dfef172a48afee98bcf3",
+    "oeq-cloudproviders": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#32d958ddfff64ca748e7e1b2eae0f0487946a487",
     "query-string": "6.4.0",
     "react": "16.8.4",
     "react-dom": "16.8.4"

--- a/autotest/IntegTester/ps/tsrc/registration.tsx
+++ b/autotest/IntegTester/ps/tsrc/registration.tsx
@@ -107,19 +107,19 @@ export function createRegistration(params: {
     vendorId: "oeq_autotest",
     providerAuth: { clientId: params.name, clientSecret: params.name },
     serviceUris: {
-      oauth: { uri: "${baseurl}access_token", authenticated: false },
-      controls: { uri: "${baseurl}controls", authenticated: true },
+      oauth: { uri: "${baseUrl}access_token", authenticated: false },
+      controls: { uri: "${baseUrl}controls", authenticated: true },
       itemNotification: {
-        uri: "${baseurl}itemNotification?uuid=${uuid}&version=${version}",
+        uri: "${baseUrl}itemNotification?uuid=${uuid}&version=${version}",
         authenticated: true
       },
       control_testcontrol: {
-        uri: "${baseurl}control.js",
+        uri: "${baseUrl}control.js",
         authenticated: false
       },
       myService: {
         uri:
-          "${baseurl}myService?param1=${param1}&param2=${param2}&from=${userid}",
+          "${baseUrl}myService?param1=${param1}&param2=${param2}&from=${userid}",
         authenticated: true
       },
       viewattachment: {

--- a/autotest/IntegTester/ps/tsrc/registration.tsx
+++ b/autotest/IntegTester/ps/tsrc/registration.tsx
@@ -106,24 +106,24 @@ export function createRegistration(params: {
     baseUrl: baseUrl,
     vendorId: "oeq_autotest",
     providerAuth: { clientId: params.name, clientSecret: params.name },
-    serviceUris: {
-      oauth: { uri: "${baseUrl}access_token", authenticated: false },
-      controls: { uri: "${baseUrl}controls", authenticated: true },
+    serviceUrls: {
+      oauth: { url: "${baseUrl}access_token", authenticated: false },
+      controls: { url: "${baseUrl}controls", authenticated: true },
       itemNotification: {
-        uri: "${baseUrl}itemNotification?uuid=${uuid}&version=${version}",
+        url: "${baseUrl}itemNotification?uuid=${uuid}&version=${version}",
         authenticated: true
       },
       control_testcontrol: {
-        uri: "${baseUrl}control.js",
+        url: "${baseUrl}control.js",
         authenticated: false
       },
       myService: {
-        uri:
+        url:
           "${baseUrl}myService?param1=${param1}&param2=${param2}&from=${userid}",
         authenticated: true
       },
       viewattachment: {
-        uri:
+        url:
           serverBase +
           "viewitem.html?attachment=${attachment}&item=${item}&version=${version}&viewer=${viewer}",
         authenticated: true

--- a/autotest/Tests/src/test/scala/equellatests/restapi/cloudprovider/package.scala
+++ b/autotest/Tests/src/test/scala/equellatests/restapi/cloudprovider/package.scala
@@ -20,14 +20,14 @@ package object cloudprovider {
 
   case class RViewer(name: String, serviceId: String)
 
-  case class RServiceUri(authenticated: Boolean, uri: String)
+  case class RServiceUrl(authenticated: Boolean, url: String)
 
   case class RCloudProviderRegistration(name: String,
                                         description: Option[String],
                                         baseUrl: String,
                                         iconUrl: Option[String],
                                         providerAuth: RCloudOAuthCredentials,
-                                        serviceUris: Map[String, RServiceUri],
+                                        serviceUrls: Map[String, RServiceUrl],
                                         viewers: Map[String, Map[String, RViewer]])
 
   case class RCloudProviderRegistrationResponse(instance: RCloudProviderInstance,
@@ -40,7 +40,7 @@ package object cloudprovider {
                                     iconUrl: Option[String],
                                     providerAuth: RCloudOAuthCredentials,
                                     oeqAuth: RCloudOAuthCredentials,
-                                    serviceUris: Map[String, RServiceUri],
+                                    serviceUrls: Map[String, RServiceUrl],
                                     viewers: Map[String, Map[String, RViewer]])
 
   case class RCloudProviderForward(url: String)


### PR DESCRIPTION
These are the three breaking changes I suggested we include before release. All three are in different commits and could be cherry-picked.

* Use Basic Auth instead of form parameters in OAuth token requests
* Change baseurl variable to baseUrl to be consistent with JSON property
* Rename properties in registration from "uri" to "url"