### PR TITLE
Only save back to state if editing

### DIFF
--- a/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
+++ b/Source/Plugins/Core/com.equella.core/scalasrc/com/tle/web/api/wizard/WizardApi.scala
@@ -79,17 +79,17 @@ class WizardApi {
     Option(sessionService.getAttribute(wizid).asInstanceOf[WizardSessionState])
       .map { wss =>
         val wsi = wss.getWizardState
-        val res = sessionService.getSessionLock.synchronized {
+        sessionService.getSessionLock.synchronized {
           if (edit) {
             wsi match {
               case wizstate: WizardState => wizstate.incrementVersion()
               case _                     => ()
             }
           }
-          f(wsi)
+          val res = f(wsi)
+          if (edit) sessionService.setAttribute(wizid, new WizardSessionState(wsi))
+          res
         }
-        sessionService.setAttribute(wizid, new WizardSessionState(wsi))
-        res
       }
       .getOrElse(throw new WebApplicationException(404))
   }


### PR DESCRIPTION
For read only wizard state calls, no need to save it back to session. The fact that it was outside of the sync block meant it was a race condition as well.