### PR TITLE
Replace reflections with classgraph

### DIFF
--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -234,7 +234,8 @@ libraryDependencies ++= Seq(
   "org.scala-sbt"          %% "io"                       % "1.1.0",
   "org.mozilla"            % "rhino"                     % "1.7R4",
   "io.lemonlabs"           %% "scala-uri"                % "1.1.5",
-  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1"
+  "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.1",
+  "io.github.classgraph"   % "classgraph"                % "4.8.41"
 )
 
 dependencyOverrides += "javax.mail" % "mail" % "1.4.7"


### PR DESCRIPTION
Using Reflections API to scan lucene JARs causes the similar issue described in https://github.com/ronmamo/reflections/issues/81#issue-95158893

An acceptable solution is to use Classgraph instead.

Both the oEQ Installer and Upgrader were tested, ensuring Tomcat stop complaining. Also the feature of using different language analyzers was tested.