### PR TITLE
Remove commons-compress from sbt

### DIFF
--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -101,7 +101,6 @@ libraryDependencies ++= Seq(
   "org.apache.axis2"          % "axis2-adb"             % axis2Version,
   "org.apache.axis2"          % "axis2-transport-http"  % axis2Version,
   "org.apache.axis2"          % "axis2-transport-local" % axis2Version,
-  "org.apache.commons"        % "commons-compress"      % "1.1",
   "org.apache.curator"        % "curator-client"        % "2.13.0",
   "org.apache.curator"        % "curator-framework"     % "2.13.0",
   "org.apache.curator"        % "curator-recipes"       % "2.13.0",


### PR DESCRIPTION
According to the discussion in PR #1036, the commons-compress library used in Equella is not the one declared in sbt. So remove the declaration. 