### PR TITLE
Bugfix/reset docker image hash

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 FROM openjdk@sha256:0e25c8428a56e32861fe996b528a107933155c98fb2a9998a4a4e9423aad734d as baseequella
 
-# Install needed tools to install and run openEQUELLA
-# Clean up the apt cache afterwards.
+# Install needed tools to install and run openEQUELLA, clean up the apt cache afterwards.
 
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk@sha256:dbdb67803b5063e9f274289bba598bf103e19d470bac4550995b28f5749f30e1 as baseequella
+FROM openjdk@sha256:0e25c8428a56e32861fe996b528a107933155c98fb2a9998a4a4e9423aad734d as baseequella
 
 # Install needed tools to install and run openEQUELLA
 # Clean up the apt cache afterwards.


### PR DESCRIPTION
This just resets the openEQUELLA Dockerfile hash for the OpenJDK base image.