### PR TITLE
Fix md5 of file attachment not saved

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WebRepository.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WebRepository.java
@@ -268,7 +268,7 @@ public class WebRepository implements LERepository {
   public FileInfo uploadStream(String filename, InputStream inp, boolean calcMd5)
       throws IOException {
     try {
-      return fsys.write(stagingHandle, filename, inp, false);
+      return fsys.write(stagingHandle, filename, inp, false, calcMd5);
     } catch (IOException io) {
       throw io;
     } catch (Exception ex) {


### PR DESCRIPTION
The FileSystemService has a few overloaded 'write' methods, but only one of those methods can generate MD5 hash. 
We have been using the one that doesn't generates MD5.