### PR TITLE
Fix textfield duplciates not allow saving item

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -39,6 +39,7 @@
     </JavaCodeStyleSettings>
     <ScalaCodeStyleSettings>
       <option name="FORMATTER" value="1" />
+      <option name="MULTILINE_STRING_SUPPORT" value="-1" />
     </ScalaCodeStyleSettings>
     <codeStyleSettings language="JAVA">
       <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -39,7 +39,6 @@
     </JavaCodeStyleSettings>
     <ScalaCodeStyleSettings>
       <option name="FORMATTER" value="1" />
-      <option name="MULTILINE_STRING_SUPPORT" value="-1" />
     </ScalaCodeStyleSettings>
     <codeStyleSettings language="JAVA">
       <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />

--- a/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/events/SectionEvent.java
+++ b/Platform/Plugins/com.tle.web.sections/src/com/tle/web/sections/events/SectionEvent.java
@@ -68,6 +68,7 @@ public interface SectionEvent<L extends EventListener> extends Comparable<Sectio
   int PRIORITY_AFTER_EVENTS = 25;
   int PRIORITY_NORMAL = 0;
   int PRIORITY_LOW = -100;
+  int PRIORITY_AFTER_EVENTS_BEFORE_NORMAL = 24;
 
   /**
    * Get the priority of this event. <br>

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/DuplicateDataSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/DuplicateDataSection.java
@@ -69,7 +69,7 @@ public class DuplicateDataSection extends WizardSection<DuplicateDataSection.Mod
     return PROP_NAME;
   }
 
-  @DirectEvent(priority = SectionEvent.PRIORITY_AFTER_EVENTS)
+  @DirectEvent(priority = SectionEvent.PRIORITY_NORMAL)
   public void submit(SectionInfo info) throws Exception {
     Model model = getModel(info);
     if (model.isSubmit()) {

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/DuplicateDataSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/DuplicateDataSection.java
@@ -69,7 +69,9 @@ public class DuplicateDataSection extends WizardSection<DuplicateDataSection.Mod
     return PROP_NAME;
   }
 
-  @DirectEvent(priority = SectionEvent.PRIORITY_NORMAL)
+  // Make sure submit gets executed after the page check event(line 127 of PageSection),
+  // and before other events whose  priorities are PRIORITY_NORMAL
+  @DirectEvent(priority = SectionEvent.PRIORITY_AFTER_EVENTS_BEFORE_NORMAL)
   public void submit(SectionInfo info) throws Exception {
     Model model = getModel(info);
     if (model.isSubmit()) {


### PR DESCRIPTION
A bit background here: when the text field duplicate check is enabled, a warning will be given if duplicates are found. Users must tick the checkbox in 'Duplicate data'  page in order to publish.  However, if the item includes attachments and one or more attachments are of type 'Web Pages', then users will not be able to save even though they tick the checkbox. 
![Screenshot from 2019-07-11 16-27-08](https://user-images.githubusercontent.com/47203811/61027656-13bfd000-a3fa-11e9-9d90-859ba0016fba.png)
![image](https://user-images.githubusercontent.com/47203811/61027741-49fd4f80-a3fa-11e9-81cd-646c0f3ae1da.png)
![image](https://user-images.githubusercontent.com/47203811/61027753-4d90d680-a3fa-11e9-963a-c70e1144adf6.png)

