### PR TITLE
revert openjdk hash used in docker file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk@sha256:58c06a2acc57665ae260d46a15bd487a4f69e286811feb7b61330558533d3fb2 as baseequella
+FROM openjdk@sha256:0e25c8428a56e32861fe996b528a107933155c98fb2a9998a4a4e9423aad734d as baseequella
 
 # Install needed tools to install and run openEQUELLA, clean up the apt cache afterwards.
 


### PR DESCRIPTION
The new openjdk hash does not work well in Develop. So revert it to the old one which works.