### PR TITLE
Add forceReRender prop to LegacyContentProps to prevent double save click bug

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -63,6 +63,8 @@ export interface LegacyContentProps {
   pathname: string;
   search: string;
   userUpdated: () => void;
+  reRender: boolean;
+  forceReRender: () => void;
   redirected: (redir: { href: string; external: boolean }) => void;
   onError: (cb: { error: ErrorResponse; fullScreen: boolean }) => void;
   render(content: PageContent | undefined): React.ReactElement;
@@ -136,6 +138,10 @@ export const LegacyContent = React.memo(function LegacyContent(
             props.userUpdated();
           }
           props.redirected({ href: content.route, external: false });
+          if (window.location.href.endsWith(content.route)) {
+            //if you are being redirected to the same URI, don't ignore the state update
+            props.forceReRender();
+          }
         } else {
           props.redirected({ href: content.href, external: true });
         }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
@@ -65,6 +65,12 @@ function IndexPage() {
     cb: (confirm: boolean) => void;
   }>();
 
+  const [reRender, setReRender] = React.useState(false);
+  function forceReRender() {
+    setReRender(!reRender);
+    setLegacyContentProps({ ...legacyContentProps, reRender: reRender });
+  }
+
   const [preventNavMessage, setPreventNavMessage] = React.useState<string>();
   const [legacyContentProps, setLegacyContentProps] = React.useState<
     LegacyContentProps
@@ -72,6 +78,8 @@ function IndexPage() {
     enabled: false,
     pathname: "",
     search: "",
+    reRender,
+    forceReRender,
     userUpdated: refreshUser,
     redirected: () => {},
     onError: () => {},


### PR DESCRIPTION
Allows for forced refresh of the state upon internal redirect, even if
the URL stays the same