### PR TITLE
Fix moderation double clicking bug

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -103,6 +103,44 @@ export const LegacyContent = React.memo(function LegacyContent(
     return relUrl.indexOf("/") == 0 ? relUrl : "/" + relUrl;
   }
 
+  function displayLegacyContent(content: LegacyContent, scrollTop: boolean) {
+    updateIncludes(content.css, content.js).then(extraCss => {
+      const pageContent = {
+        ...content,
+        contentId: v4(),
+        afterHtml: () => {
+          deleteElements(extraCss);
+          if (scrollTop) {
+            document.documentElement.scrollTop = 0;
+          }
+        }
+      } as PageContent;
+      if (content.userUpdated) {
+        props.userUpdated();
+      }
+      setContent(pageContent);
+    });
+  }
+
+  function changeInternalRoute(content: ChangeRoute, submitValues: StateData) {
+    if (content.userUpdated) {
+      props.userUpdated();
+    }
+    // Ensure the operation is one of those item-related commands
+    const isNavCommand = submitValues.event__.toString() === "nav.command";
+    // Ensure current URL is as same as the route to be redirected to
+    const isSameUrl = window.location.href.endsWith(content.route);
+    // Ensure it's a moderation page
+    const isModeration = content.route.indexOf("_taskState") > -1;
+    if (isSameUrl && isNavCommand && isModeration) {
+      // The essence of the second clicking is submitting the form. So here manually do it.
+      const rerender = stdSubmit(false);
+      rerender.call("");
+    } else {
+      props.redirected({ href: content.route, external: false });
+    }
+  }
+
   function submitCurrentForm(
     fullScreen: boolean,
     scrollTop: boolean,
@@ -115,40 +153,9 @@ export const LegacyContent = React.memo(function LegacyContent(
         if (callback) {
           callback(content);
         } else if (isPageContent(content)) {
-          updateIncludes(content.css, content.js).then(extraCss => {
-            const pageContent = {
-              ...content,
-              contentId: v4(),
-              afterHtml: () => {
-                deleteElements(extraCss);
-                if (scrollTop) {
-                  document.documentElement.scrollTop = 0;
-                }
-              }
-            } as PageContent;
-            if (content.userUpdated) {
-              props.userUpdated();
-            }
-            setContent(pageContent);
-          });
+          displayLegacyContent(content, scrollTop);
         } else if (isChangeRoute(content)) {
-          if (content.userUpdated) {
-            props.userUpdated();
-          }
-          // Ensure the operation is one of those item-related commands
-          const isNavCommand =
-            submitValues.event__.toString() === "nav.command";
-          // Ensure current URL is as same as the route to be redirected to
-          const isSameUrl = window.location.href.endsWith(content.route);
-          // Ensure it's a moderation page
-          const isModeration = content.route.indexOf("_taskState") > -1;
-          if (isSameUrl && isNavCommand && isModeration) {
-            // The essence of the second clicking is submitting the form. So here manually do it.
-            const rerender = stdSubmit(false);
-            rerender.call("");
-          } else {
-            props.redirected({ href: content.route, external: false });
-          }
+          changeInternalRoute(content, submitValues);
         } else {
           props.redirected({ href: content.href, external: true });
         }

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -135,7 +135,20 @@ export const LegacyContent = React.memo(function LegacyContent(
           if (content.userUpdated) {
             props.userUpdated();
           }
-          props.redirected({ href: content.route, external: false });
+          // Ensure the operation is one of those item-related commands
+          const isNavCommand =
+            submitValues.event__.toString() === "nav.command";
+          // Ensure current URL is as same as the route to be redirected to
+          const isSameUrl = window.location.href.endsWith(content.route);
+          // Ensure it's a moderation page
+          const isModeration = content.route.indexOf("_taskState") > -1;
+          if (isSameUrl && isNavCommand && isModeration) {
+            // The essence of the second clicking is submitting the form. So here manually do it.
+            const rerender = stdSubmit(false);
+            rerender.call("");
+          } else {
+            props.redirected({ href: content.route, external: false });
+          }
         } else {
           props.redirected({ href: content.href, external: true });
         }


### PR DESCRIPTION
Fix the double clicking bug in moderation. 
I have tested  contributing items (one or multiple pages with a cloud control), editing, cloning, new versioning, deleting and searching items, login/logout and a lots more. 
It has been working fine so far on my machine. If anybody can checkout and do some local experiments, that is really appreciated!!