### PR TITLE
Fix newUI same URL redirect bug

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -104,6 +104,25 @@ export const LegacyContent = React.memo(function LegacyContent(
     return relUrl.indexOf("/") == 0 ? relUrl : "/" + relUrl;
   }
 
+  function updatePageContent(content: LegacyContent, scrollTop: boolean) {
+    updateIncludes(content.css, content.js).then(extraCss => {
+      const pageContent = {
+        ...content,
+        contentId: v4(),
+        afterHtml: () => {
+          deleteElements(extraCss);
+          if (scrollTop) {
+            document.documentElement.scrollTop = 0;
+          }
+        }
+      } as PageContent;
+      if (content.userUpdated) {
+        props.userUpdated();
+      }
+      setContent(pageContent);
+    });
+  }
+
   function submitCurrentForm(
     fullScreen: boolean,
     scrollTop: boolean,
@@ -116,22 +135,7 @@ export const LegacyContent = React.memo(function LegacyContent(
         if (callback) {
           callback(content);
         } else if (isPageContent(content)) {
-          updateIncludes(content.css, content.js).then(extraCss => {
-            const pageContent = {
-              ...content,
-              contentId: v4(),
-              afterHtml: () => {
-                deleteElements(extraCss);
-                if (scrollTop) {
-                  document.documentElement.scrollTop = 0;
-                }
-              }
-            } as PageContent;
-            if (content.userUpdated) {
-              props.userUpdated();
-            }
-            setContent(pageContent);
-          });
+          updatePageContent(content, scrollTop);
         } else if (isChangeRoute(content)) {
           if (content.userUpdated) {
             props.userUpdated();

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -127,19 +127,12 @@ export const LegacyContent = React.memo(function LegacyContent(
       props.userUpdated();
     }
     // Ensure the operation is one of those item-related commands
-    const submitEvent = submitValues.event__;
-    const isNavCommand = () => {
-      if (submitEvent != undefined) {
-        return submitEvent.toString() === "nav.command";
-      } else {
-        return false;
-      }
-    };
+    const isNavCommand = submitValues.event__.toString() === "nav.command";
     // Ensure current URL is as same as the route to be redirected to
     const isSameUrl = window.location.href.endsWith(content.route);
     // Ensure it's a moderation page
     const isModeration = content.route.indexOf("_taskState") > -1;
-    if (isSameUrl && isNavCommand() && isModeration) {
+    if (isSameUrl && isNavCommand && isModeration) {
       // The essence of the second clicking is submitting the form. So here manually do it.
       const rerender = stdSubmit(false);
       rerender.call("");

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx
@@ -62,6 +62,7 @@ export interface LegacyContentProps {
   enabled: boolean;
   pathname: string;
   search: string;
+  locationKey?: string;
   userUpdated: () => void;
   redirected: (redir: { href: string; external: boolean }) => void;
   onError: (cb: { error: ErrorResponse; fullScreen: boolean }) => void;
@@ -219,7 +220,7 @@ export const LegacyContent = React.memo(function LegacyContent(
       setContent(undefined);
       updateStylesheets([]).then(deleteElements);
     }
-  }, [enabled, props.pathname, props.search]);
+  }, [enabled, props.pathname, props.search, props.locationKey]);
 
   return props.render(enabled ? content : undefined);
 });

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/LegacyPage.tsx
@@ -114,6 +114,7 @@ export const LegacyPage = React.memo(
         enabled: true,
         pathname: location.pathname,
         search: location.search,
+        locationKey: location.key,
         redirected,
         onError
       }));

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/mainui/index.tsx
@@ -72,6 +72,7 @@ function IndexPage() {
     enabled: false,
     pathname: "",
     search: "",
+    locationKey: "",
     userUpdated: refreshUser,
     redirected: () => {},
     onError: () => {},


### PR DESCRIPTION
So the problem with some actions not being triggered first go is because when the Purescript / Typescript conversion happened, the trigger for calling the legacy page submit API moved into React effect hook dependency list but it didn't take into account redirecting to the same URL. [LegacyPage.tsx](https://github.com/apereo/openEQUELLA/blob/develop/Source/Plugins/Core/com.equella.core/js/tsrc/legacycontent/LegacyContent.tsx#L215)

In order to fix it properly we can use the "key" property of the react router location object, which will have a different value for each time a history location is pushed, thus it can trigger even with the same path and query.

The original fix is just a workaround which is checking for values very specific to the moderation page, however this problem will happen anywhere in oeq, so it's best to fix it properly.

I have run the new ui autotests on this and it fixed a number of tests. 
