### PR TITLE
link attachment duplicate check

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/universal/handlers/UrlHandler.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/controls/universal/handlers/UrlHandler.java
@@ -116,6 +116,27 @@ public class UrlHandler extends BasicAbstractAttachmentHandler<AbstractAttachmen
   }
 
   @Override
+  public void remove(SectionInfo info, Attachment attachment, boolean willBeReplaced) {
+    super.remove(info, attachment, willBeReplaced);
+    removeDuplicateInfo(attachment.getUuid());
+  }
+
+  @Override
+  public void saveEdited(SectionInfo info, Attachment attachment) {
+    super.saveEdited(info, attachment);
+    // When editing a link, its old duplicate information must be removed
+    removeDuplicateInfo(attachment.getUuid());
+  }
+
+  private void removeDuplicateInfo(String uuid) {
+    boolean isDuplicateCheck =
+        dialogState.getControlConfiguration().getBooleanAttribute("LINK_DUPLICATION_CHECK");
+    if (isDuplicateCheck) {
+      dialogState.getRepository().getState().getDuplicateData().remove(uuid);
+    }
+  }
+
+  @Override
   public boolean isMultipleAllowed(SectionInfo info) {
     return false;
   }

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/WizardService.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/WizardService.java
@@ -83,7 +83,9 @@ public interface WizardService extends ScriptEvaluator {
 
   void checkDuplicateUrls(WizardState state, String[] urls);
 
-  void checkDuplicateAttachments(WizardState state, String fileName, String fileUuid);
+  void checkFileAttachmentDuplicate(WizardState state, String fileName, String fileUuid);
+
+  void checkLinkAttachmentDuplicate(WizardState state, String url, String linkUuid);
 
   ScriptContext createScriptContext(
       WizardState state, WizardPage page, HTMLControl control, Map<String, Object> attributes);

--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WizardServiceImpl.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/impl/WizardServiceImpl.java
@@ -744,7 +744,17 @@ public class WizardServiceImpl
   }
 
   @Override
-  public void checkDuplicateAttachments(WizardState state, String fileName, String fileUuid) {
+  public void checkLinkAttachmentDuplicate(WizardState state, String url, String linkUuid) {
+    final String ignoreItem = state.getItemId().getUuid();
+    final ItemDefinition itemdef = state.getItemDefinition();
+    List<ItemId> duplicateLinkAttachments = itemService.getItemsWithUrl(url, itemdef, ignoreItem);
+    if (duplicateLinkAttachments.size() > 0) {
+      setDuplicates(state, linkUuid, url, duplicateLinkAttachments, true, true);
+    }
+  }
+
+  @Override
+  public void checkFileAttachmentDuplicate(WizardState state, String fileName, String fileUuid) {
     try {
       String md5 = fileSystemService.getMD5Checksum(state.getFileHandle(), fileName);
       List<Attachment> duplicateFileAttachments =


### PR DESCRIPTION
* add the feature of link attachment duplicate check
* update duplicate information when editing, replacing or deleting a link attachment

Please note that the duplicate warning message and duplicate data page now can be affected by both file and link attachments.