### PR TITLE
Fix cloud provider / server side xml sync problems

### DIFF
--- a/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/PagesSection.java
+++ b/Source/Plugins/Core/com.equella.core/src/com/tle/web/wizard/section/PagesSection.java
@@ -18,7 +18,6 @@
 
 package com.tle.web.wizard.section;
 
-import com.dytech.devlib.PropBagEx;
 import com.google.common.collect.Lists;
 import com.tle.annotation.NonNullByDefault;
 import com.tle.beans.entity.itemdef.Wizard;
@@ -120,17 +119,14 @@ public class PagesSection extends WizardSection<PagesSection.PagesModel>
     }
     final WebWizardPage page = getPage(info, renderedPage, false, model.getCurrentPage() != -1);
     if (model.isSubmit()) {
-      String xmlDoc = model.getXmldoc();
-      if (xmlDoc != null) {
-        PropBagEx itemXml = state.getItemxml();
-        PropBagEx cloudControlXml = new PropBagEx(xmlDoc);
-        itemXml.mergeTree(cloudControlXml);
-        state.setItemXml(itemXml.toString());
-      }
       info.queueEvent(
           new AbstractDirectEvent(SectionEvent.PRIORITY_AFTER_EVENTS, getSectionId()) {
             @Override
             public void fireDirect(SectionId sectionId, SectionInfo info) throws Exception {
+              String xmlDoc = model.getXmldoc();
+              if (xmlDoc != null) {
+                state.setItemXml(xmlDoc);
+              }
               final LERepository repository = page.getRepository();
               repository.runUpdate(
                   wsi -> {


### PR DESCRIPTION
There are two problems which combined to cause the "uuid" as title problem:

* The cloud provider xml is only sent to the server when the "validate" global jquery event is called - the save button doesn't trigger this when opening the "publish" dialog, so the form fields need to be setup in the "presubmit" handler
* The cloud provider xml is being used when it shouldn't be - it should only be used inside the 
`SectionEvent.PRIORITY_AFTER_EVENTS` queued event, as this event get cancelled by the publish buttons.