### PR TITLE
Minimise docker image size and optimise layer order

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,42 +6,34 @@ FROM openjdk@sha256:0e25c8428a56e32861fe996b528a107933155c98fb2a9998a4a4e9423aad
 ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
-RUN \
-  apt-get update \
-  && apt-get install -y \
+RUN useradd -ms /bin/bash equella \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
     curl \
     imagemagick \
     libav-tools \
     unzip \
   && rm -rf /var/lib/apt/lists/*
 
-FROM baseequella as installer
-
 # Install openEQUELLA
+FROM baseequella as installer
 
 ARG OEQ_INSTALL_FILE=equella-installer-2019.1.zip
 
 COPY ["$OEQ_INSTALL_FILE","defaults.xml", "./"]
 
 RUN unzip $OEQ_INSTALL_FILE -d /tmp \
-    && mv /tmp/equella-installer-* /equella-installer \
-    && java -jar /equella-installer/enterprise-install.jar --unsupported defaults.xml
-
-FROM baseequella as equella
-
-RUN useradd -ms /bin/bash equella
-WORKDIR /home/equella
-COPY --from=installer /home/equella/equella equella
-RUN mkdir -p /home/equella/equella/filestore/ \
-    && mkdir -p /home/equella/equella/freetext/ \
-    && chown -R equella:equella equella
+  && mv /tmp/equella-installer-* /equella-installer \
+  && java -jar /equella-installer/enterprise-install.jar --unsupported defaults.xml \
+  && mkdir -p /home/equella/equella/filestore/ \
+  && mkdir -p /home/equella/equella/freetext/ \
+  && chown -R equella:equella /home/equella
 WORKDIR /home/equella/equella
 USER equella
-VOLUME ["/home/equella/equella/filestore/", "/home/equella/equella/freetext/"]
-
 COPY learningedge-log4j.properties learningedge-config/
 
-# At this point openEQUELLA is installed.
+# Now build the final image
+FROM baseequella as equella
 
 EXPOSE 8080
 
@@ -50,8 +42,8 @@ ARG JVM_ARGS
 ENV MEM $MEM
 ENV JVM_ARGS $JVM_ARGS
 
-# Properties in the optional-config, mandatory-config, and hibernate files can be 
-# overridden by oEQ logic via environment variables by changing '.' to '_', 
+# Properties in the optional-config, mandatory-config, and hibernate files can be
+# overridden by oEQ logic via environment variables by changing '.' to '_',
 # uppercasing, and prepending "EQ_" to the name.
 
 ARG EQ_HTTP_PORT=8080
@@ -68,5 +60,10 @@ ENV EQ_HIBERNATE_CONNECTION_USERNAME $EQ_HIBERNATE_CONNECTION_USERNAME
 
 ARG EQ_HIBERNATE_CONNECTION_PASSWORD=password
 ENV EQ_HIBERNATE_CONNECTION_PASSWORD $EQ_HIBERNATE_CONNECTION_PASSWORD
+
+COPY --from=installer /home/equella/equella /home/equella/equella
+WORKDIR /home/equella/equella
+USER equella
+VOLUME ["/home/equella/equella/filestore/", "/home/equella/equella/freetext/"]
 
 CMD java -Xmx${MEM}m $JVM_ARGS -cp learningedge-config:server/equella-server.jar com.tle.core.equella.runner.EQUELLAServer


### PR DESCRIPTION
There were two issues:

1. The docker image was weighing in at 2.06G (now 1.28G)
2. A new docker image for a new build resulted in almost all the layers
   having to be pulled - as they'd all change.

Large Docker Image

This was primarily caused by a double up of the layer which contained
the installed equella which was caused by the RUN statement after it had
been copied into the final equella image. But seeing this is a
multi-stage build with one stage dedicated to building / installing, it
made sense for it to completely finalise the installed equella directory
ready to copy into the final image.

To do this various logic was moved into the install 'stage' and effort
was also undertaken to minimise RUN statements.

Excessive layer churn

In docker each statement in a Dockerfile creates a layer. When
rebuilding an image, if a statement results in a changed layer then all
following layers will also change.

In the case of this build, the only statement which should really result
in a change to a layer is that with the new equella install - i.e. where
it copies from the `installer` image. So it is best to have this as late
as possible in the Dockerfile to ensure all previous layers can be
re-used as much as possible.