### PR TITLE
Remove unused bouncycastle dependency

### DIFF
--- a/Source/Server/equellaserver/build.sbt
+++ b/Source/Server/equellaserver/build.sbt
@@ -173,7 +173,6 @@ libraryDependencies ++= Seq(
     ExclusionRule(organization = "org.slf4j",
                   name = "slf4j-log4j12")
   ),
-  "org.bouncycastle"       % "bcprov-jdk15on"    % "1.62",
   "org.ccil.cowan.tagsoup" % "tagsoup"           % "1.2.1",
   "org.codehaus.woodstox"  % "stax2-api"         % "3.1.3",
   "org.codehaus.woodstox"  % "woodstox-core-asl" % "4.2.0",


### PR DESCRIPTION
This bouncycastle dependency was conflicting with GitHub classpath (used in the recent multi-language stemming support update) and stops the installerZip from building. 
After looking into it, it was discovered that this dependency is not directly used in the code, and removing it allows installerZip to work. We'll see how the CI goes with it. 