### PR TITLE
Fix invalid <a/> tag in harvestlist.ftl, add robots meta tag to new UI

### DIFF
--- a/Source/Plugins/Core/com.equella.core/resources/view/harvestlist.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/harvestlist.ftl
@@ -19,7 +19,7 @@
 <h1>Items</h1>
 <ul>
 	<#list m.results as result>
-		<li><a href="${result.url?html}"/><@bundle value=result.bundleId default=result.itemId /></a></li>
+		<li><a href="${result.url?html}"><@bundle value=result.bundleId default=result.itemId /></a></li>
 	</#list>
 </ul>
 </div>

--- a/Source/Plugins/Core/com.equella.core/resources/view/layouts/outer/react.ftl
+++ b/Source/Plugins/Core/com.equella.core/resources/view/layouts/outer/react.ftl
@@ -5,6 +5,7 @@
     <head>
       <meta http-equiv="X-UA-Compatible" content="IE=edge" >
     	<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+      <meta name="robots" content="noindex, follow">
     	<meta name="viewport" content="width=device-width, initial-scale=1">
     	<base href="${baseHref}">
 


### PR DESCRIPTION
Allows DiscoverabilityTest - Harvest test to work in the new UI, and
also makes the harvest.do links appear as links in the new UI. Up 
until now, they were just text.