### PR TITLE
Make DRMPrivilegeTest pass in the new UI

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMPrivilegeTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMPrivilegeTest.java
@@ -15,9 +15,13 @@ public class DRMPrivilegeTest extends AbstractTest {
   private static final String DPITEM_URL = "items/0c2b2d62-19a2-ce71-4d59-f852c33e6413/1/";
   private static final String VITEM_URL = "items/63810b7d-2534-d4ff-1d2f-ddae660f596d/1/";
   private static final String VPITEM_URL = "items/e98420d8-f010-513b-9aa5-74ece19fc0ec/1/";
+  private static final String PAGE_HTML = "page.html";
+  private static final String OLD_UI = "?old=true";
 
   private void assertDenied() {
-    assertEquals(new ErrorPage(context).get().getMainErrorMessage(), "Access denied");
+    assertEquals(
+        new ErrorPage(context, new ErrorPage(context).usingNewUI()).get().getMainErrorMessage(),
+        "Access denied");
   }
 
   private void assertAgreement() {
@@ -36,14 +40,14 @@ public class DRMPrivilegeTest extends AbstractTest {
   public void testWithDiscover() {
     LoginPage loginPage = new LoginPage(context).load();
     loginPage.login("DRMPriv", "``````");
-    openPage(DITEM_URL);
+    openPage(DITEM_URL + OLD_UI);
     assertAgreement();
-    openPage(DITEM_URL + "page.html");
+    openPage(DITEM_URL + PAGE_HTML + OLD_UI);
     assertDenied();
     loginPage.logout();
-    openPage(DITEM_URL);
+    openPage(DITEM_URL + OLD_UI);
     assertAgreement();
-    openPage(DITEM_URL + "page.html");
+    openPage(DITEM_URL + PAGE_HTML + OLD_UI);
     loginPage.checkLoaded();
   }
 
@@ -51,14 +55,14 @@ public class DRMPrivilegeTest extends AbstractTest {
   public void testWithDiscoverNoPreview() {
     LoginPage loginPage = new LoginPage(context).load();
     loginPage.login("DRMPriv", "``````");
-    openPage(DPITEM_URL);
+    openPage(DPITEM_URL + OLD_UI);
     assertAgreement();
-    openPage(DPITEM_URL + "page.html");
+    openPage(DPITEM_URL + PAGE_HTML + OLD_UI);
     assertDenied();
     loginPage.logout();
-    openPage(DPITEM_URL);
+    openPage(DPITEM_URL + OLD_UI);
     assertLogin();
-    openPage(DPITEM_URL + "page.html");
+    openPage(DPITEM_URL + PAGE_HTML + OLD_UI);
     assertLogin();
   }
 
@@ -66,14 +70,14 @@ public class DRMPrivilegeTest extends AbstractTest {
   public void testWithView() {
     LoginPage loginPage = new LoginPage(context).load();
     loginPage.login("DRMPriv", "``````");
-    openPage(VITEM_URL);
+    openPage(VITEM_URL + OLD_UI);
     assertAgreement();
-    openPage(VITEM_URL + "page.html");
+    openPage(VITEM_URL + PAGE_HTML + OLD_UI);
     assertAgreement();
     loginPage.logout();
-    openPage(VITEM_URL);
+    openPage(VITEM_URL + OLD_UI);
     assertAgreement();
-    openPage(VITEM_URL + "page.html");
+    openPage(VITEM_URL + PAGE_HTML + OLD_UI);
     assertAgreement();
   }
 
@@ -81,14 +85,14 @@ public class DRMPrivilegeTest extends AbstractTest {
   public void testWithViewNoPreview() {
     LoginPage loginPage = new LoginPage(context).load();
     loginPage.login("DRMPriv", "``````");
-    openPage(VPITEM_URL);
+    openPage(VPITEM_URL + OLD_UI);
     assertAgreement();
-    openPage(VPITEM_URL + "page.html");
+    openPage(VPITEM_URL + PAGE_HTML + OLD_UI);
     assertAgreement();
     loginPage.logout();
-    openPage(VPITEM_URL);
+    openPage(VPITEM_URL + OLD_UI);
     assertLogin();
-    openPage(VPITEM_URL + "page.html");
+    openPage(VPITEM_URL + PAGE_HTML + OLD_UI);
     assertLogin();
   }
 
@@ -96,9 +100,9 @@ public class DRMPrivilegeTest extends AbstractTest {
   public void testWithNothing() {
     LoginPage loginPage = new LoginPage(context).load();
     loginPage.login("DRMNoPriv", "``````");
-    openPage(VITEM_URL);
+    openPage(VITEM_URL + "?old=true");
     assertDenied();
-    openPage(VITEM_URL + "page.html");
+    openPage(VITEM_URL + PAGE_HTML + OLD_UI);
     assertDenied();
   }
 }


### PR DESCRIPTION
There is a bug in the new UI which prevents navigating directly (via URL or fullscreen button) to an attachment that has DRM. In the old UI, the DRM agreement prompt would pop up, in the new UI it simply says that the item does not exist. 