### PR TITLE
Make the getToken method wait for a token

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/AbstractRestApiTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/AbstractRestApiTest.java
@@ -159,7 +159,11 @@ public abstract class AbstractRestApiTest extends AbstractSessionTest {
 
   protected String getToken() throws IOException {
     if (token == null) {
-      token = requestToken(clients.get(0));
+      if (clients.size() >= 1) {
+        token = requestToken(clients.get(0));
+      } else {
+        token = getToken();
+      }
     }
     return token;
   }

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/AbstractRestApiTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/AbstractRestApiTest.java
@@ -7,7 +7,6 @@ import com.google.common.io.Closeables;
 import com.tle.common.Pair;
 import com.tle.webtests.framework.PageContext;
 import com.tle.webtests.framework.TestInstitution;
-import com.tle.webtests.pageobject.LoginPage;
 import com.tle.webtests.test.AbstractSessionTest;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -62,6 +61,7 @@ import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.codehaus.jackson.node.ArrayNode;
 import org.codehaus.jackson.node.ObjectNode;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testng.Assert;
 import org.testng.AssertJUnit;
 import org.testng.annotations.BeforeClass;
@@ -159,8 +159,7 @@ public abstract class AbstractRestApiTest extends AbstractSessionTest {
   }
 
   protected String getToken() throws IOException {
-    LoginPage page = new LoginPage(context);
-    page.getWaiter().until((webDriver -> clients.size() >= 1));
+    new WebDriverWait(context.getDriver(), 30).until((webDriver -> clients.size() >= 1));
     if (token == null) {
       token = requestToken(clients.get(0));
     }

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/AbstractRestApiTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/webservices/rest/AbstractRestApiTest.java
@@ -7,6 +7,7 @@ import com.google.common.io.Closeables;
 import com.tle.common.Pair;
 import com.tle.webtests.framework.PageContext;
 import com.tle.webtests.framework.TestInstitution;
+import com.tle.webtests.pageobject.LoginPage;
 import com.tle.webtests.test.AbstractSessionTest;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -158,12 +159,10 @@ public abstract class AbstractRestApiTest extends AbstractSessionTest {
   }
 
   protected String getToken() throws IOException {
+    LoginPage page = new LoginPage(context);
+    page.getWaiter().until((webDriver -> clients.size() >= 1));
     if (token == null) {
-      if (clients.size() >= 1) {
-        token = requestToken(clients.get(0));
-      } else {
-        token = getToken();
-      }
+      token = requestToken(clients.get(0));
     }
     return token;
   }


### PR DESCRIPTION
Common issue with many of the rest tests in the new UI is the check for a token was called before the token existed. 