### PR TITLE
Fix the slow typing issue in new search UI

### DIFF
--- a/Source/Plugins/Core/com.equella.core/js/package.json
+++ b/Source/Plugins/Core/com.equella.core/js/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@types/jest": "22.2.3",
     "@types/luxon": "1.15.1",
+    "@types/lodash": "4.14.136",
     "@types/tinymce": "4.5.22",
     "@types/node": "9.6.49",
     "@types/react": "16.8.23",

--- a/Source/Plugins/Core/com.equella.core/js/package.json
+++ b/Source/Plugins/Core/com.equella.core/js/package.json
@@ -37,6 +37,7 @@
     "history": "4.9.0",
     "jspolyfill-array.prototype.find": "0.1.3",
     "luxon": "1.16.0",
+    "lodash": "4.17.11",
     "material-ui-pickers": "2.2.4",
     "oeq-cloudproviders": "git+https://github.com/apereo/openEQUELLA-cloudprovidersdk.git#32d958ddfff64ca748e7e1b2eae0f0487946a487",
     "parcel-bundler": "1.12.1",

--- a/Source/Plugins/Core/com.equella.core/js/tsrc/components/AppBarQuery.tsx
+++ b/Source/Plugins/Core/com.equella.core/js/tsrc/components/AppBarQuery.tsx
@@ -3,13 +3,16 @@ import { WithStyles, Icon, withStyles, Theme } from "@material-ui/core";
 import { fade } from "@material-ui/core/styles/colorManipulator";
 import { createStyles } from "@material-ui/core/styles";
 import { commonString } from "../util/commonstrings";
+import { debounce } from "lodash";
 
 interface AppBarQueryProps {
   onSearch?: (query?: string) => void;
   onChange: (query: string) => void;
   query: string;
 }
-
+interface AppBarQueryState {
+  searchText: string;
+}
 const styles = (theme: Theme) =>
   createStyles({
     queryWrapper: {
@@ -46,17 +49,39 @@ const styles = (theme: Theme) =>
   });
 
 class AppBarQuery extends React.Component<
-  AppBarQueryProps & WithStyles<"queryWrapper" | "queryIcon" | "queryField">
+  AppBarQueryProps & WithStyles<"queryWrapper" | "queryIcon" | "queryField">,
+  AppBarQueryState
 > {
   constructor(
     props: AppBarQueryProps &
       WithStyles<"queryWrapper" | "queryIcon" | "queryField">
   ) {
     super(props);
+    this.state = {
+      searchText: ""
+    };
   }
 
+  // Do a search after user stops typing for 500 milliseconds.
+  // Purescript passes a concrete search function to onChange.
+  debouncedSearch = debounce(() => {
+    this.props.onChange(this.state.searchText);
+  }, 500);
+
+  handleTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState(
+      {
+        searchText: e.target.value
+      },
+      () => {
+        this.debouncedSearch();
+      }
+    );
+  };
+
   render() {
-    const { classes, onChange, query } = this.props;
+    const { classes } = this.props;
+    const { searchText } = this.state;
     return (
       <div className={classes.queryWrapper}>
         <div className={classes.queryIcon}>
@@ -66,8 +91,8 @@ class AppBarQuery extends React.Component<
           type="text"
           aria-label={commonString.action.search}
           className={classes.queryField}
-          value={query}
-          onChange={e => onChange(e.target.value)}
+          value={searchText}
+          onChange={this.handleTextChange}
         />
       </div>
     );


### PR DESCRIPTION
Debounce the search  functionality in new search UI to improve user experience.
A search is triggered after user stops typing for half second.

Successfully tested with throttling in local environment.