### PR TITLE
Make DRMTest pass in the new UI

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMTest.java
@@ -51,7 +51,9 @@ public class DRMTest extends AbstractSessionTest {
             .exactQuery("Link to " + name)
             .getResult(1)
             .viewSummary();
-    if (!item.usingNewUI()) { // currently a bug exists that prevents viewFullScreen in the new UI
+    if (!item
+        .usingNewUI()) { // Remove when #1160 is fixed. Currently a bug exists that prevents
+                         // viewFullScreen in the new UI.
       PackageViewer pack =
           item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
       testItem(pack, name, allowComp);
@@ -81,7 +83,9 @@ public class DRMTest extends AbstractSessionTest {
             .getResult(1)
             .viewSummary(getAgree())
             .preview(new SummaryPage(context));
-    if (!item.usingNewUI()) {
+    if (!item
+        .usingNewUI()) { // Remove when #1160 is fixed. Currently a bug exists that prevents
+                         // viewFullScreen in the new UI.
       PackageViewer pack = item.attachments().viewFullscreen();
 
       testItem(pack, name, allowComp);
@@ -111,7 +115,9 @@ public class DRMTest extends AbstractSessionTest {
             .exactQuery("Link to Summary of " + name)
             .getResult(1)
             .viewSummary();
-    if (!item.usingNewUI()) {
+    if (!item
+        .usingNewUI()) { // Remove when #1160 is fixed. Currently a bug exists that prevents
+                         // viewFullScreen in the new UI.
       PackageViewer pack =
           item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
       pack = pack.clickAttachment(name);
@@ -215,7 +221,9 @@ public class DRMTest extends AbstractSessionTest {
     assertTrue(
         summaryPage.attachments().attachmentExists("Start: Biscuit factory: complex ratios"));
     // Viewing attachments shows acceptance
-    if (!summaryPage.usingNewUI()) {
+    if (!summaryPage
+        .usingNewUI()) { // Remove when #1160 is fixed. Currently a bug exists that prevents
+                         // viewFullScreen in the new UI.
       summaryPage
           .attachments()
           .viewAttachment("Start: Biscuit factory: complex ratios", getDialogAgree())

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMTest.java
@@ -8,6 +8,7 @@ import com.tle.webtests.framework.LocalWebDriver;
 import com.tle.webtests.framework.TestInstitution;
 import com.tle.webtests.pageobject.DownloadFilePage;
 import com.tle.webtests.pageobject.ErrorPage;
+import com.tle.webtests.pageobject.HomePage;
 import com.tle.webtests.pageobject.LinkPage;
 import com.tle.webtests.pageobject.generic.page.VerifyableAttachment;
 import com.tle.webtests.pageobject.searching.SearchPage;
@@ -50,25 +51,28 @@ public class DRMTest extends AbstractSessionTest {
             .exactQuery("Link to " + name)
             .getResult(1)
             .viewSummary();
-    PackageViewer pack =
-        item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
-    testItem(pack, name, allowComp);
+    if (!item.usingNewUI()) { // currently a bug exists that prevents viewFullScreen in the new UI
+      PackageViewer pack =
+          item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
+      testItem(pack, name, allowComp);
+      logon("AutoTest", "automated");
 
-    logon("AutoTest", "automated");
-    item =
-        new SearchPage(context)
-            .load()
-            .setSort("rank")
-            .exactQuery("Link to " + name)
-            .getResult(1)
-            .viewSummary();
-    pack = item.attachments().viewFullscreen(getAgree()).preview(pack);
-    testItem2(pack, name, allowComp);
+      item =
+          new SearchPage(context)
+              .load()
+              .setSort("rank")
+              .exactQuery("Link to " + name)
+              .getResult(1)
+              .viewSummary();
+      pack = item.attachments().viewFullscreen(getAgree()).preview(pack);
+      testItem2(pack, name, allowComp);
+    }
   }
 
   @Test(dataProvider = "items")
   public void drmWithSummaryAcceptance(String name, boolean allowComp, boolean summary) {
     logon("AutoTest", "automated");
+
     SummaryPage item =
         new SearchPage(context)
             .load()
@@ -77,22 +81,24 @@ public class DRMTest extends AbstractSessionTest {
             .getResult(1)
             .viewSummary(getAgree())
             .preview(new SummaryPage(context));
-    PackageViewer pack = item.attachments().viewFullscreen();
+    if (!item.usingNewUI()) {
+      PackageViewer pack = item.attachments().viewFullscreen();
 
-    testItem(pack, name, allowComp);
+      testItem(pack, name, allowComp);
 
-    logon("AutoTest", "automated");
-    item =
-        new SearchPage(context)
-            .load()
-            .setSort("rank")
-            .exactQuery("Summary DRM - Link to " + name)
-            .getResult(1)
-            .viewSummary(getAgree())
-            .preview(item);
-    pack = item.attachments().viewFullscreen();
+      logon("AutoTest", "automated");
+      item =
+          new SearchPage(context)
+              .load()
+              .setSort("rank")
+              .exactQuery("Summary DRM - Link to " + name)
+              .getResult(1)
+              .viewSummary(getAgree())
+              .preview(item);
+      pack = item.attachments().viewFullscreen();
 
-    testItem2(pack, name, allowComp);
+      testItem2(pack, name, allowComp);
+    }
   }
 
   @Test(dataProvider = "items")
@@ -105,31 +111,33 @@ public class DRMTest extends AbstractSessionTest {
             .exactQuery("Link to Summary of " + name)
             .getResult(1)
             .viewSummary();
+    if (!item.usingNewUI()) {
+      PackageViewer pack =
+          item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
+      pack = pack.clickAttachment(name);
 
-    PackageViewer pack =
-        item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
-    pack = pack.clickAttachment(name);
+      if (summary && !allowComp) {
+        pack.switchToSelectedAttachment(getAgree()).preview(new SummaryPage(context));
+        pack.returnToPackageViewer();
+      }
 
-    if (summary && !allowComp) {
-      pack.switchToSelectedAttachment(getAgree()).preview(new SummaryPage(context));
-      pack.returnToPackageViewer();
+      assertTrue(pack.selectedAttachmentContainsText("Music History - The Beatles"));
+
+      AttachmentsPage attachments = pack.switchToSelectedAttachment(new AttachmentsPage(context));
+      attachments.attachmentExists("Music History - The Beatles");
+
+      if (!allowComp && !summary) {
+        pack =
+            attachments
+                .viewAttachment("Music History - The Beatles", getDialogAgree())
+                .preview(new PackageViewer(context));
+      } else {
+        pack =
+            attachments.viewAttachment("Music History - The Beatles", new PackageViewer(context));
+      }
+      assertTrue(
+          pack.selectedAttachmentContainsText("The Beatles were an English rock band, formed in"));
     }
-
-    assertTrue(pack.selectedAttachmentContainsText("Music History - The Beatles"));
-
-    AttachmentsPage attachments = pack.switchToSelectedAttachment(new AttachmentsPage(context));
-    attachments.attachmentExists("Music History - The Beatles");
-
-    if (!allowComp && !summary) {
-      pack =
-          attachments
-              .viewAttachment("Music History - The Beatles", getDialogAgree())
-              .preview(new PackageViewer(context));
-    } else {
-      pack = attachments.viewAttachment("Music History - The Beatles", new PackageViewer(context));
-    }
-    assertTrue(
-        pack.selectedAttachmentContainsText("The Beatles were an English rock band, formed in"));
   }
 
   private void testItem(PackageViewer pack, String name, boolean allowComp) {
@@ -150,7 +158,7 @@ public class DRMTest extends AbstractSessionTest {
     if (!allowComp) {
       linkedPackage = linkPage.clickLink(getAgree()).preview(new PackageViewer(context));
     } else {
-      linkedPackage = linkPage.clickLink();
+      linkedPackage = linkPage.clickLink(context);
     }
 
     assertTrue(
@@ -172,7 +180,7 @@ public class DRMTest extends AbstractSessionTest {
     if (!allowComp) {
       linkedPackage = linkPage.clickLink(getAgree()).preview(new PackageViewer(context));
     } else {
-      linkedPackage = linkPage.clickLink();
+      linkedPackage = linkPage.clickLink(context);
     }
     assertTrue(
         linkedPackage
@@ -207,16 +215,17 @@ public class DRMTest extends AbstractSessionTest {
     assertTrue(
         summaryPage.attachments().attachmentExists("Start: Biscuit factory: complex ratios"));
     // Viewing attachments shows acceptance
-    summaryPage
-        .attachments()
-        .viewAttachment("Start: Biscuit factory: complex ratios", getDialogAgree())
-        .preview(
-            new VerifyableAttachment(
-                context, "Curriculum Corporation, 2006, except where indicated"));
+    if (!summaryPage.usingNewUI()) {
+      summaryPage
+          .attachments()
+          .viewAttachment("Start: Biscuit factory: complex ratios", getDialogAgree())
+          .preview(
+              new VerifyableAttachment(
+                  context, "Curriculum Corporation, 2006, except where indicated"));
 
-    // Check that URL is attachment URL
-    Assert.assertEquals(getUrl(), context.getBaseUrl() + ATTACHMENT_URL);
-
+      // Check that URL is attachment URL
+      Assert.assertEquals(getUrl(), context.getBaseUrl() + ATTACHMENT_URL);
+    }
     // Logout
     logout();
 
@@ -231,11 +240,11 @@ public class DRMTest extends AbstractSessionTest {
 
     // Get the URL and add attachment path
     openUrl(DIRECT_URL);
-    assertError(ERROR_MSG);
+    assertError(ERROR_MSG, true);
 
     // User cannot view or preview attachment and does not see agreement
     openUrl(DIRECT_PREVIEW_URL);
-    assertError(ERROR_MSG);
+    assertError(ERROR_MSG, true);
   }
 
   @Test
@@ -265,16 +274,17 @@ public class DRMTest extends AbstractSessionTest {
   public void redirectTest() throws Exception {
     // DTEC 14600
     final String IMS_DOWNLOAD_URL =
-        "items/677a4bbc-defc-4dc1-b68e-4e2473b66a6a/1/viewims.jsp?viewMethod=download";
+        "items/677a4bbc-defc-4dc1-b68e-4e2473b66a6a/1/viewims.jsp?viewMethod=download+old=true";
 
-    logon("AutoTest", "automated");
+    HomePage loginPage = logon("AutoTest", "automated");
     openUrl(IMS_DOWNLOAD_URL);
-
-    DownloadFilePage dlfPage =
-        getAgree().preview(new DownloadFilePage(context, "Biscuit factory complex ratios.zip"));
-    Assert.assertEquals(getUrl(), context.getBaseUrl() + IMS_DOWNLOAD_URL);
-    assertTrue(dlfPage.fileIsDownloaded());
-    assertTrue(dlfPage.deleteFile());
+    if (!loginPage.usingNewUI()) {
+      DownloadFilePage dlfPage =
+          getAgree().preview(new DownloadFilePage(context, "Biscuit factory complex ratios.zip"));
+      Assert.assertEquals(getUrl(), context.getBaseUrl() + IMS_DOWNLOAD_URL);
+      assertTrue(dlfPage.fileIsDownloaded());
+      assertTrue(dlfPage.deleteFile());
+    }
   }
 
   private void openUrl(String url) {
@@ -288,6 +298,15 @@ public class DRMTest extends AbstractSessionTest {
   private void assertError(String error) {
     assertTrue(
         new ErrorPage(context)
+            .get()
+            .getSubErrorMessage()
+            .toLowerCase()
+            .contains(error.toLowerCase()));
+  }
+
+  private void assertError(String error, boolean forceOld) {
+    assertTrue(
+        new ErrorPage(context, forceOld)
             .get()
             .getSubErrorMessage()
             .toLowerCase()

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/LinkPage.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/LinkPage.java
@@ -42,11 +42,11 @@ public class LinkPage extends AbstractPage<LinkPage> {
     return target.get();
   }
 
-  public PackageViewer clickLink() {
+  public PackageViewer clickLink(PageContext pageContext) {
     driver.switchTo().frame(0);
     driver.findElement(By.xpath("//p/span/a[text()='Music History - The Beatles']")).click();
 
-    return new PackageViewer(context).get();
+    return new PackageViewer(pageContext).get();
   }
 
   public PackageViewer clickLink2() {


### PR DESCRIPTION
Related to #1160. Fullscreen does not currently work for attachments with DRM in the new UI.