### PR TITLE
Bugfix/fix quota exceed test

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/QuotaExceedTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/QuotaExceedTest.java
@@ -12,6 +12,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Random;
 import java.util.UUID;
+import org.openqa.selenium.By;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -47,12 +49,13 @@ public class QuotaExceedTest extends AbstractSessionTest {
     WizardPageTab wizardPage = contributePage.openWizard(GENERIC_TESTING_COLLECTION);
     wizardPage.editbox(1, "Massive file");
     wizardPage.addSingleFile(4, twoMegFile.toURL());
-    Assert.assertTrue(
-        wizardPage
-            .save()
-            .publishInvalid(new WizardErrorPage(context))
-            .getError()
-            .startsWith("Maximum user quota of 1 MB exceeded. "));
+    WizardErrorPage errorPage = wizardPage.save().publishInvalid(new WizardErrorPage(context));
+    // Wait for the error page is completed loaded
+    errorPage
+        .getWaiter()
+        .until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("div.error")));
+    String errorText = errorPage.getError();
+    Assert.assertTrue(errorText.startsWith("Maximum user quota of 1 MB exceeded. "));
 
     contributePage = new ContributePage(context).load();
     wizardPage = contributePage.openWizard(GENERIC_TESTING_COLLECTION);

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/QuotaExceedTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/contribute/QuotaExceedTest.java
@@ -12,8 +12,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Random;
 import java.util.UUID;
-import org.openqa.selenium.By;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -49,11 +47,8 @@ public class QuotaExceedTest extends AbstractSessionTest {
     WizardPageTab wizardPage = contributePage.openWizard(GENERIC_TESTING_COLLECTION);
     wizardPage.editbox(1, "Massive file");
     wizardPage.addSingleFile(4, twoMegFile.toURL());
-    WizardErrorPage errorPage = wizardPage.save().publishInvalid(new WizardErrorPage(context));
-    // Wait for the error page is completed loaded
-    errorPage
-        .getWaiter()
-        .until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("div.error")));
+
+    WizardErrorPage errorPage = wizardPage.save().publishErrorPage(new WizardErrorPage(context));
     String errorText = errorPage.getError();
     Assert.assertTrue(errorText.startsWith("Maximum user quota of 1 MB exceeded. "));
 

--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMTest.java
@@ -51,9 +51,8 @@ public class DRMTest extends AbstractSessionTest {
             .exactQuery("Link to " + name)
             .getResult(1)
             .viewSummary();
-    if (!item
-        .usingNewUI()) { // Remove when #1160 is fixed. Currently a bug exists that prevents
-                         // viewFullScreen in the new UI.
+    if (!item.usingNewUI()) { // Remove when #1160 is fixed. Currently a bug exists that prevents
+      // viewFullScreen in the new UI.
       PackageViewer pack =
           item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
       testItem(pack, name, allowComp);
@@ -83,9 +82,9 @@ public class DRMTest extends AbstractSessionTest {
             .getResult(1)
             .viewSummary(getAgree())
             .preview(new SummaryPage(context));
-    if (!item
-        .usingNewUI()) { // Remove when #1160 is fixed. Currently a bug exists that prevents
-                         // viewFullScreen in the new UI.
+    // Remove when #1160 is fixed. Currently a bug exists that prevents
+    // viewFullScreen in the new UI.
+    if (!item.usingNewUI()) {
       PackageViewer pack = item.attachments().viewFullscreen();
 
       testItem(pack, name, allowComp);
@@ -115,9 +114,9 @@ public class DRMTest extends AbstractSessionTest {
             .exactQuery("Link to Summary of " + name)
             .getResult(1)
             .viewSummary();
-    if (!item
-        .usingNewUI()) { // Remove when #1160 is fixed. Currently a bug exists that prevents
-                         // viewFullScreen in the new UI.
+    // Remove when #1160 is fixed. Currently a bug exists that prevents
+    // viewFullScreen in the new UI.
+    if (!item.usingNewUI()) {
       PackageViewer pack =
           item.attachments().viewFullscreen(getAgree()).preview(new PackageViewer(context));
       pack = pack.clickAttachment(name);
@@ -223,7 +222,7 @@ public class DRMTest extends AbstractSessionTest {
     // Viewing attachments shows acceptance
     if (!summaryPage
         .usingNewUI()) { // Remove when #1160 is fixed. Currently a bug exists that prevents
-                         // viewFullScreen in the new UI.
+      // viewFullScreen in the new UI.
       summaryPage
           .attachments()
           .viewAttachment("Start: Biscuit factory: complex ratios", getDialogAgree())

--- a/autotest/OldTests/testng-codebuild.yaml
+++ b/autotest/OldTests/testng-codebuild.yaml
@@ -4,150 +4,150 @@ threadCount: 1
 tests:
   - name: OneAfterAnother
     classes:
-      #      - com.tle.webtests.test.searching.BrowsebyTest
-      #      - com.tle.webtests.test.searching.CloudSearchingTest
-      #      - com.tle.webtests.test.searching.GallerySearchTest
-      #      - com.tle.webtests.test.searching.GuidedSearchingTest
-      #      - com.tle.webtests.test.searching.PowerSearchTest
-      #      - com.tle.webtests.test.searching.SearchAutoCompleteTest
-      #      - com.tle.webtests.test.searching.SearchEnhancementsTest
-      #      - com.tle.webtests.test.searching.SearchFiltersTest
-      #      - com.tle.webtests.test.searching.SearchSettingsTest
-      #      - com.tle.webtests.test.searching.SearchUrlSupportedParamsTest
-      #      - com.tle.webtests.test.searching.UTF8SearchingTest
-      #      - com.tle.webtests.test.searching.manage.BulkMetadataEditTest
-      #      - com.tle.webtests.test.searching.manage.BulkScriptExecutionTest
-      #      - com.tle.webtests.test.searching.manage.ManageResourcesFavouritesTest
-      #      - com.tle.webtests.test.searching.manage.ManageResourcesNoScrapbookTest
-      #      - com.tle.webtests.test.searching.manage.ManageResourcesSearchTest
-      #      - com.tle.webtests.test.searching.indexing.AutomaticIndexingOfCommentsTest
-      #      - com.tle.webtests.test.searching.indexing.AutomaticIndexingTest
-      #      - com.tle.webtests.test.searching.indexing.FileIndexingTest
-      #      - com.tle.webtests.test.searching.hierarchy.HierarchyTopicTest
-      #      - com.tle.webtests.test.contribute.controls.AllControlsTest
-      #      - com.tle.webtests.test.contribute.controls.BannedExtensionTest
-      #      - com.tle.webtests.test.contribute.controls.FileSizeRestrictionTest
-      #      - com.tle.webtests.test.contribute.controls.GroupsAndDisabling
-      #      - com.tle.webtests.test.contribute.controls.HTMLEditBoxTest
-      #      - com.tle.webtests.test.contribute.controls.IncorrectMimetypeTest
-      #      - com.tle.webtests.test.contribute.controls.MaxAttachmentsTest
-      #      - com.tle.webtests.test.contribute.controls.PackageAndNavigationTest
-      #      - com.tle.webtests.test.contribute.controls.RepeaterTest
-      #      - com.tle.webtests.test.contribute.controls.TaxonomyControlsTest
-      #      - com.tle.webtests.test.contribute.ContributeXmlTest
-      #      - com.tle.webtests.test.contribute.DiscoverabilityTest
-      #      - com.tle.webtests.test.contribute.EquellaConnectorTest
-      #      - com.tle.webtests.test.contribute.ItemUnlock
-      #      - com.tle.webtests.test.contribute.MetadataMappingTest
+      - com.tle.webtests.test.searching.BrowsebyTest
+      - com.tle.webtests.test.searching.CloudSearchingTest
+      - com.tle.webtests.test.searching.GallerySearchTest
+      - com.tle.webtests.test.searching.GuidedSearchingTest
+      - com.tle.webtests.test.searching.PowerSearchTest
+      - com.tle.webtests.test.searching.SearchAutoCompleteTest
+      - com.tle.webtests.test.searching.SearchEnhancementsTest
+      - com.tle.webtests.test.searching.SearchFiltersTest
+      - com.tle.webtests.test.searching.SearchSettingsTest
+      - com.tle.webtests.test.searching.SearchUrlSupportedParamsTest
+      - com.tle.webtests.test.searching.UTF8SearchingTest
+      - com.tle.webtests.test.searching.manage.BulkMetadataEditTest
+      - com.tle.webtests.test.searching.manage.BulkScriptExecutionTest
+      - com.tle.webtests.test.searching.manage.ManageResourcesFavouritesTest
+      - com.tle.webtests.test.searching.manage.ManageResourcesNoScrapbookTest
+      - com.tle.webtests.test.searching.manage.ManageResourcesSearchTest
+      - com.tle.webtests.test.searching.indexing.AutomaticIndexingOfCommentsTest
+      - com.tle.webtests.test.searching.indexing.AutomaticIndexingTest
+      - com.tle.webtests.test.searching.indexing.FileIndexingTest
+      - com.tle.webtests.test.searching.hierarchy.HierarchyTopicTest
+      - com.tle.webtests.test.contribute.controls.AllControlsTest
+      - com.tle.webtests.test.contribute.controls.BannedExtensionTest
+      - com.tle.webtests.test.contribute.controls.FileSizeRestrictionTest
+      - com.tle.webtests.test.contribute.controls.GroupsAndDisabling
+      - com.tle.webtests.test.contribute.controls.HTMLEditBoxTest
+      - com.tle.webtests.test.contribute.controls.IncorrectMimetypeTest
+      - com.tle.webtests.test.contribute.controls.MaxAttachmentsTest
+      - com.tle.webtests.test.contribute.controls.PackageAndNavigationTest
+      - com.tle.webtests.test.contribute.controls.RepeaterTest
+      - com.tle.webtests.test.contribute.controls.TaxonomyControlsTest
+      - com.tle.webtests.test.contribute.ContributeXmlTest
+      - com.tle.webtests.test.contribute.DiscoverabilityTest
+      - com.tle.webtests.test.contribute.EquellaConnectorTest
+      - com.tle.webtests.test.contribute.ItemUnlock
+      - com.tle.webtests.test.contribute.MetadataMappingTest
       - com.tle.webtests.test.contribute.QuotaExceedTest
-#      - com.tle.webtests.test.contribute.ResumableWizardsTest
-#      - com.tle.webtests.test.contribute.SelectAndDisplayThumbnailTest
-#      - com.tle.webtests.test.contribute.SelectionSessionTest
-#      - com.tle.webtests.test.contribute.StaticMetadataTest
-#      - com.tle.webtests.test.contribute.UniquenessTest
-#      - com.tle.webtests.test.contribute.VaryingContribPageNmbrSaveTest
-#      - com.tle.webtests.test.contribute.WizardBreadcrumbs
-#      - com.tle.webtests.test.contribute.WizardConfigTest
-#      - com.tle.webtests.test.contribute.controls.attachments.AttachmentControlTest
-#      - com.tle.webtests.test.contribute.controls.attachments.FileAttachmentControlTest
-#      - com.tle.webtests.test.contribute.controls.attachments.LTIAttachmentControlTest
-#      - com.tle.webtests.test.contribute.controls.attachments.MultipleAttachmentControlTest
-#      - com.tle.webtests.test.contribute.controls.attachments.RestrictedAttachmentsTest
-#      - com.tle.webtests.test.contribute.controls.asc.AdvancedScriptControlTests
-#      - com.tle.webtests.test.contribute.controls.asc.PropBagExTest
-#      - com.tle.webtests.test.contribute.controls.asc.ScriptedDisplayTemplateTest
-#      - com.tle.webtests.test.contribute.controls.asc.ScriptedPortletTests
-#      - com.tle.webtests.test.reporting.RunReportTest
-#      - com.tle.webtests.test.viewing.DisplayNodesTest
-#      - com.tle.webtests.test.viewing.ItemHistoryTest
-#      - com.tle.webtests.test.viewing.ItemServletRedirectTest
-#      - com.tle.webtests.test.viewing.ItemSummaryTest
-#      - com.tle.webtests.test.viewing.MimeTypesTest
-#- com.tle.webtests.test.viewing.ModerationHistoryPreviewVal
-#- com.tle.webtests.rewrite.ModerationRejectedComments
-#      - com.tle.webtests.test.viewing.SearchResultTemplateTest
-#      - com.tle.webtests.test.viewing.ServeSSITest
-#- com.tle.webtests.test.viewing.ShowHideOwnerCollaborator
-#      - com.tle.webtests.test.viewing.SummaryXSLTTest
-#      - com.tle.webtests.test.viewing.VersionShowAllTest
-#      - com.tle.webtests.test.viewing.ViewerTest
-#      - com.tle.webtests.test.admin.CustomLinksTest
-#      - com.tle.webtests.test.admin.ServerMessageTest
-#      - com.tle.webtests.test.admin.MultiLingualTest
-#      - com.tle.webtests.test.accessibility.AccessibilityModeTest
-#      - com.tle.webtests.test.acl.ACLTest
-#      - com.tle.webtests.test.cal.CALActivationsMetadataTest
-#      - com.tle.webtests.test.cal.CALActivationsRolloverTest
-#      - com.tle.webtests.test.cal.CALAgreementTest
-#      - com.tle.webtests.test.cal.CALBookActivationTest
-#      - com.tle.webtests.test.cal.CALBookRulesTest
-#      - com.tle.webtests.test.cal.CALExtractTest
-#      - com.tle.webtests.test.cal.CALJournalRulesTest
-#      - com.tle.webtests.test.cal.CALPrivilegeTest
-#      - com.tle.webtests.test.cal.CALSoapInterfaceTest
-#      - com.tle.webtests.test.cal.CALViolationTest
-#      - com.tle.webtests.test.dashboard.PortalsTest
-#      - com.tle.webtests.test.drm.DRMPrivilegeTest
-#      - com.tle.webtests.test.drm.DRMTest
-#      - com.tle.webtests.test.drm.DRMTestWithCleanup
-#      - com.tle.webtests.test.drm.WizardDRMTest
-#      - com.tle.webtests.test.dynamichierarchy.DynamicHierarchyTest
-#      - com.tle.webtests.test.importexport.CloneTest
-#      - com.tle.webtests.test.importexport.ExportTest
-#      - com.tle.webtests.test.importexport.ImportTest
-#      - com.tle.webtests.test.myresources.favourites.FavouriteItemsTest
-#      - com.tle.webtests.test.myresources.favourites.FavouritesInIntegrationTest
-#      - com.tle.webtests.test.myresources.favourites.ResourceSelectorFavouritesTest
-#      - com.tle.webtests.test.myresources.MyResourcesTest
-#      - com.tle.webtests.test.myresources.MyResourcesWebPageTest
-#      - com.tle.webtests.test.users.DisplayDateFormatTest
-#      - com.tle.webtests.test.users.LoginSettingsTest
-#      - com.tle.webtests.test.users.TokenLoginTest
-#      - com.tle.webtests.test.users.UserPasswordTest
-#      - com.tle.webtests.test.usersscripts.UserScriptTest
-#      - com.tle.webtests.test.webservices.rest.ActivationApiTest
-#      - com.tle.webtests.test.webservices.rest.CollectionApiTest
-#      - com.tle.webtests.test.webservices.rest.CommentApiTest
-#      - com.tle.webtests.test.webservices.rest.CourseApiTest
-#      - com.tle.webtests.test.webservices.rest.DynaCollectionApiTest
-#      - com.tle.webtests.test.webservices.rest.FileApiTest
-#      - com.tle.webtests.test.webservices.rest.FileListingApiTest
-#      - com.tle.webtests.test.webservices.rest.HierarchyApiTest
-#      - com.tle.webtests.test.webservices.rest.ItemApiActionsTest
-#      - com.tle.webtests.test.webservices.rest.ItemApiContributeTest
-#      - com.tle.webtests.test.webservices.rest.ItemApiEditTest
-#      - com.tle.webtests.test.webservices.rest.ItemApiLockTest
-#      - com.tle.webtests.test.webservices.rest.ItemApiQuickContributeTest
-#      - com.tle.webtests.test.webservices.rest.ItemApiRelationTest
-#      - com.tle.webtests.test.webservices.rest.ItemApiViewTest
-#      - com.tle.webtests.test.webservices.rest.MyResourcesApiTest
-#      - com.tle.webtests.test.webservices.rest.NotificationsApiTest
-#      - com.tle.webtests.test.webservices.rest.OAuthClientEditorTest
-#      - com.tle.webtests.test.webservices.rest.SchemaApiTest
-#      - com.tle.webtests.test.webservices.rest.ScrapbookApiTest
-#      - com.tle.webtests.test.webservices.rest.SearchApiTest
-#      - com.tle.webtests.test.webservices.rest.TasksApiTest
-#      - com.tle.webtests.test.webservices.rest.TaxonomyApiTest
-#      - com.tle.webtests.test.webservices.rest.UserGroupManagementApiTest
-#      - com.tle.webtests.test.webservices.soap.Soap51Test
-#      - com.tle.webtests.test.webservices.soap.SoapServicesTest
-#      - com.tle.webtests.test.webservices.OAIEndpointTest
-#      - com.tle.webtests.test.webservices.SRWTest
-#      - com.tle.webtests.test.workflow.assignment.AutoAssignBiggerTest
-#      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingByContributorRoleTest
-#      - com.tle.webtests.test.workflow.assignment.AutoAssignSimpleTest
-#      - com.tle.webtests.test.workflow.movetolive.MoveToLiveDuringWorkflowTest
-#      - com.tle.webtests.test.workflow.assignment.WorkflowAssignmentTest
-#      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingBySchemaElementTest
-#      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingByItemStatusTest
-#      - com.tle.webtests.test.workflow.rejection.NewVersionTest
-#      - com.tle.webtests.test.workflow.rejection.RejectionPointsTest
-#      - com.tle.webtests.test.workflow.rejection.RejectionPointsWithDecisionNodesTest
-#      - com.tle.webtests.test.workflow.rejection.RejectionTest
-#      - com.tle.webtests.test.workflow.ClonedItemTest
-#      - com.tle.webtests.test.workflow.ManageTasksTest
-#      - com.tle.webtests.test.workflow.MessageToModeratorTest
-#      - com.tle.webtests.test.workflow.ModerationProgressTest
-#      - com.tle.webtests.test.workflow.TaskListNavigationTest
-#      - com.tle.webtests.test.workflow.TasksNotificationsTopbarTest
-#      - com.tle.webtests.test.workflow.TasksSortingAndFilteringTest
+      - com.tle.webtests.test.contribute.ResumableWizardsTest
+      - com.tle.webtests.test.contribute.SelectAndDisplayThumbnailTest
+      - com.tle.webtests.test.contribute.SelectionSessionTest
+      - com.tle.webtests.test.contribute.StaticMetadataTest
+      - com.tle.webtests.test.contribute.UniquenessTest
+      - com.tle.webtests.test.contribute.VaryingContribPageNmbrSaveTest
+      - com.tle.webtests.test.contribute.WizardBreadcrumbs
+      - com.tle.webtests.test.contribute.WizardConfigTest
+      - com.tle.webtests.test.contribute.controls.attachments.AttachmentControlTest
+      - com.tle.webtests.test.contribute.controls.attachments.FileAttachmentControlTest
+      - com.tle.webtests.test.contribute.controls.attachments.LTIAttachmentControlTest
+      - com.tle.webtests.test.contribute.controls.attachments.MultipleAttachmentControlTest
+      - com.tle.webtests.test.contribute.controls.attachments.RestrictedAttachmentsTest
+      - com.tle.webtests.test.contribute.controls.asc.AdvancedScriptControlTests
+      - com.tle.webtests.test.contribute.controls.asc.PropBagExTest
+      - com.tle.webtests.test.contribute.controls.asc.ScriptedDisplayTemplateTest
+      - com.tle.webtests.test.contribute.controls.asc.ScriptedPortletTests
+      - com.tle.webtests.test.reporting.RunReportTest
+      - com.tle.webtests.test.viewing.DisplayNodesTest
+      - com.tle.webtests.test.viewing.ItemHistoryTest
+      - com.tle.webtests.test.viewing.ItemServletRedirectTest
+      - com.tle.webtests.test.viewing.ItemSummaryTest
+      - com.tle.webtests.test.viewing.MimeTypesTest
+      #- com.tle.webtests.test.viewing.ModerationHistoryPreviewVal
+      #- com.tle.webtests.rewrite.ModerationRejectedComments
+      - com.tle.webtests.test.viewing.SearchResultTemplateTest
+      - com.tle.webtests.test.viewing.ServeSSITest
+      #- com.tle.webtests.test.viewing.ShowHideOwnerCollaborator
+      - com.tle.webtests.test.viewing.SummaryXSLTTest
+      - com.tle.webtests.test.viewing.VersionShowAllTest
+      - com.tle.webtests.test.viewing.ViewerTest
+      - com.tle.webtests.test.admin.CustomLinksTest
+      - com.tle.webtests.test.admin.ServerMessageTest
+      - com.tle.webtests.test.admin.MultiLingualTest
+      - com.tle.webtests.test.accessibility.AccessibilityModeTest
+      - com.tle.webtests.test.acl.ACLTest
+      - com.tle.webtests.test.cal.CALActivationsMetadataTest
+      - com.tle.webtests.test.cal.CALActivationsRolloverTest
+      - com.tle.webtests.test.cal.CALAgreementTest
+      - com.tle.webtests.test.cal.CALBookActivationTest
+      - com.tle.webtests.test.cal.CALBookRulesTest
+      - com.tle.webtests.test.cal.CALExtractTest
+      - com.tle.webtests.test.cal.CALJournalRulesTest
+      - com.tle.webtests.test.cal.CALPrivilegeTest
+      - com.tle.webtests.test.cal.CALSoapInterfaceTest
+      - com.tle.webtests.test.cal.CALViolationTest
+      - com.tle.webtests.test.dashboard.PortalsTest
+      - com.tle.webtests.test.drm.DRMPrivilegeTest
+      - com.tle.webtests.test.drm.DRMTest
+      - com.tle.webtests.test.drm.DRMTestWithCleanup
+      - com.tle.webtests.test.drm.WizardDRMTest
+      - com.tle.webtests.test.dynamichierarchy.DynamicHierarchyTest
+      - com.tle.webtests.test.importexport.CloneTest
+      - com.tle.webtests.test.importexport.ExportTest
+      - com.tle.webtests.test.importexport.ImportTest
+      - com.tle.webtests.test.myresources.favourites.FavouriteItemsTest
+      - com.tle.webtests.test.myresources.favourites.FavouritesInIntegrationTest
+      - com.tle.webtests.test.myresources.favourites.ResourceSelectorFavouritesTest
+      - com.tle.webtests.test.myresources.MyResourcesTest
+      - com.tle.webtests.test.myresources.MyResourcesWebPageTest
+      - com.tle.webtests.test.users.DisplayDateFormatTest
+      - com.tle.webtests.test.users.LoginSettingsTest
+      - com.tle.webtests.test.users.TokenLoginTest
+      - com.tle.webtests.test.users.UserPasswordTest
+      - com.tle.webtests.test.usersscripts.UserScriptTest
+      - com.tle.webtests.test.webservices.rest.ActivationApiTest
+      - com.tle.webtests.test.webservices.rest.CollectionApiTest
+      - com.tle.webtests.test.webservices.rest.CommentApiTest
+      - com.tle.webtests.test.webservices.rest.CourseApiTest
+      - com.tle.webtests.test.webservices.rest.DynaCollectionApiTest
+      - com.tle.webtests.test.webservices.rest.FileApiTest
+      - com.tle.webtests.test.webservices.rest.FileListingApiTest
+      - com.tle.webtests.test.webservices.rest.HierarchyApiTest
+      - com.tle.webtests.test.webservices.rest.ItemApiActionsTest
+      - com.tle.webtests.test.webservices.rest.ItemApiContributeTest
+      - com.tle.webtests.test.webservices.rest.ItemApiEditTest
+      - com.tle.webtests.test.webservices.rest.ItemApiLockTest
+      - com.tle.webtests.test.webservices.rest.ItemApiQuickContributeTest
+      - com.tle.webtests.test.webservices.rest.ItemApiRelationTest
+      - com.tle.webtests.test.webservices.rest.ItemApiViewTest
+      - com.tle.webtests.test.webservices.rest.MyResourcesApiTest
+      - com.tle.webtests.test.webservices.rest.NotificationsApiTest
+      - com.tle.webtests.test.webservices.rest.OAuthClientEditorTest
+      - com.tle.webtests.test.webservices.rest.SchemaApiTest
+      - com.tle.webtests.test.webservices.rest.ScrapbookApiTest
+      - com.tle.webtests.test.webservices.rest.SearchApiTest
+      - com.tle.webtests.test.webservices.rest.TasksApiTest
+      - com.tle.webtests.test.webservices.rest.TaxonomyApiTest
+      - com.tle.webtests.test.webservices.rest.UserGroupManagementApiTest
+      - com.tle.webtests.test.webservices.soap.Soap51Test
+      - com.tle.webtests.test.webservices.soap.SoapServicesTest
+      - com.tle.webtests.test.webservices.OAIEndpointTest
+      - com.tle.webtests.test.webservices.SRWTest
+      - com.tle.webtests.test.workflow.assignment.AutoAssignBiggerTest
+      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingByContributorRoleTest
+      - com.tle.webtests.test.workflow.assignment.AutoAssignSimpleTest
+      - com.tle.webtests.test.workflow.movetolive.MoveToLiveDuringWorkflowTest
+      - com.tle.webtests.test.workflow.assignment.WorkflowAssignmentTest
+      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingBySchemaElementTest
+      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingByItemStatusTest
+      - com.tle.webtests.test.workflow.rejection.NewVersionTest
+      - com.tle.webtests.test.workflow.rejection.RejectionPointsTest
+      - com.tle.webtests.test.workflow.rejection.RejectionPointsWithDecisionNodesTest
+      - com.tle.webtests.test.workflow.rejection.RejectionTest
+      - com.tle.webtests.test.workflow.ClonedItemTest
+      - com.tle.webtests.test.workflow.ManageTasksTest
+      - com.tle.webtests.test.workflow.MessageToModeratorTest
+      - com.tle.webtests.test.workflow.ModerationProgressTest
+      - com.tle.webtests.test.workflow.TaskListNavigationTest
+      - com.tle.webtests.test.workflow.TasksNotificationsTopbarTest
+      - com.tle.webtests.test.workflow.TasksSortingAndFilteringTest

--- a/autotest/OldTests/testng-codebuild.yaml
+++ b/autotest/OldTests/testng-codebuild.yaml
@@ -4,150 +4,150 @@ threadCount: 1
 tests:
   - name: OneAfterAnother
     classes:
-      - com.tle.webtests.test.searching.BrowsebyTest
-      - com.tle.webtests.test.searching.CloudSearchingTest
-      - com.tle.webtests.test.searching.GallerySearchTest
-      - com.tle.webtests.test.searching.GuidedSearchingTest
-      - com.tle.webtests.test.searching.PowerSearchTest
-      - com.tle.webtests.test.searching.SearchAutoCompleteTest
-      - com.tle.webtests.test.searching.SearchEnhancementsTest
-      - com.tle.webtests.test.searching.SearchFiltersTest
-      - com.tle.webtests.test.searching.SearchSettingsTest
-      - com.tle.webtests.test.searching.SearchUrlSupportedParamsTest
-      - com.tle.webtests.test.searching.UTF8SearchingTest
-      - com.tle.webtests.test.searching.manage.BulkMetadataEditTest
-      - com.tle.webtests.test.searching.manage.BulkScriptExecutionTest
-      - com.tle.webtests.test.searching.manage.ManageResourcesFavouritesTest
-      - com.tle.webtests.test.searching.manage.ManageResourcesNoScrapbookTest
-      - com.tle.webtests.test.searching.manage.ManageResourcesSearchTest
-      - com.tle.webtests.test.searching.indexing.AutomaticIndexingOfCommentsTest
-      - com.tle.webtests.test.searching.indexing.AutomaticIndexingTest
-      - com.tle.webtests.test.searching.indexing.FileIndexingTest
-      - com.tle.webtests.test.searching.hierarchy.HierarchyTopicTest
-      - com.tle.webtests.test.contribute.controls.AllControlsTest
-      - com.tle.webtests.test.contribute.controls.BannedExtensionTest
-      - com.tle.webtests.test.contribute.controls.FileSizeRestrictionTest
-      - com.tle.webtests.test.contribute.controls.GroupsAndDisabling
-      - com.tle.webtests.test.contribute.controls.HTMLEditBoxTest
-      - com.tle.webtests.test.contribute.controls.IncorrectMimetypeTest
-      - com.tle.webtests.test.contribute.controls.MaxAttachmentsTest
-      - com.tle.webtests.test.contribute.controls.PackageAndNavigationTest
-      - com.tle.webtests.test.contribute.controls.RepeaterTest
-      - com.tle.webtests.test.contribute.controls.TaxonomyControlsTest
-      - com.tle.webtests.test.contribute.ContributeXmlTest
-      - com.tle.webtests.test.contribute.DiscoverabilityTest
-      - com.tle.webtests.test.contribute.EquellaConnectorTest
-      - com.tle.webtests.test.contribute.ItemUnlock
-      - com.tle.webtests.test.contribute.MetadataMappingTest
+      #      - com.tle.webtests.test.searching.BrowsebyTest
+      #      - com.tle.webtests.test.searching.CloudSearchingTest
+      #      - com.tle.webtests.test.searching.GallerySearchTest
+      #      - com.tle.webtests.test.searching.GuidedSearchingTest
+      #      - com.tle.webtests.test.searching.PowerSearchTest
+      #      - com.tle.webtests.test.searching.SearchAutoCompleteTest
+      #      - com.tle.webtests.test.searching.SearchEnhancementsTest
+      #      - com.tle.webtests.test.searching.SearchFiltersTest
+      #      - com.tle.webtests.test.searching.SearchSettingsTest
+      #      - com.tle.webtests.test.searching.SearchUrlSupportedParamsTest
+      #      - com.tle.webtests.test.searching.UTF8SearchingTest
+      #      - com.tle.webtests.test.searching.manage.BulkMetadataEditTest
+      #      - com.tle.webtests.test.searching.manage.BulkScriptExecutionTest
+      #      - com.tle.webtests.test.searching.manage.ManageResourcesFavouritesTest
+      #      - com.tle.webtests.test.searching.manage.ManageResourcesNoScrapbookTest
+      #      - com.tle.webtests.test.searching.manage.ManageResourcesSearchTest
+      #      - com.tle.webtests.test.searching.indexing.AutomaticIndexingOfCommentsTest
+      #      - com.tle.webtests.test.searching.indexing.AutomaticIndexingTest
+      #      - com.tle.webtests.test.searching.indexing.FileIndexingTest
+      #      - com.tle.webtests.test.searching.hierarchy.HierarchyTopicTest
+      #      - com.tle.webtests.test.contribute.controls.AllControlsTest
+      #      - com.tle.webtests.test.contribute.controls.BannedExtensionTest
+      #      - com.tle.webtests.test.contribute.controls.FileSizeRestrictionTest
+      #      - com.tle.webtests.test.contribute.controls.GroupsAndDisabling
+      #      - com.tle.webtests.test.contribute.controls.HTMLEditBoxTest
+      #      - com.tle.webtests.test.contribute.controls.IncorrectMimetypeTest
+      #      - com.tle.webtests.test.contribute.controls.MaxAttachmentsTest
+      #      - com.tle.webtests.test.contribute.controls.PackageAndNavigationTest
+      #      - com.tle.webtests.test.contribute.controls.RepeaterTest
+      #      - com.tle.webtests.test.contribute.controls.TaxonomyControlsTest
+      #      - com.tle.webtests.test.contribute.ContributeXmlTest
+      #      - com.tle.webtests.test.contribute.DiscoverabilityTest
+      #      - com.tle.webtests.test.contribute.EquellaConnectorTest
+      #      - com.tle.webtests.test.contribute.ItemUnlock
+      #      - com.tle.webtests.test.contribute.MetadataMappingTest
       - com.tle.webtests.test.contribute.QuotaExceedTest
-      - com.tle.webtests.test.contribute.ResumableWizardsTest
-      - com.tle.webtests.test.contribute.SelectAndDisplayThumbnailTest
-      - com.tle.webtests.test.contribute.SelectionSessionTest
-      - com.tle.webtests.test.contribute.StaticMetadataTest
-      - com.tle.webtests.test.contribute.UniquenessTest
-      - com.tle.webtests.test.contribute.VaryingContribPageNmbrSaveTest
-      - com.tle.webtests.test.contribute.WizardBreadcrumbs
-      - com.tle.webtests.test.contribute.WizardConfigTest
-      - com.tle.webtests.test.contribute.controls.attachments.AttachmentControlTest
-      - com.tle.webtests.test.contribute.controls.attachments.FileAttachmentControlTest
-      - com.tle.webtests.test.contribute.controls.attachments.LTIAttachmentControlTest
-      - com.tle.webtests.test.contribute.controls.attachments.MultipleAttachmentControlTest
-      - com.tle.webtests.test.contribute.controls.attachments.RestrictedAttachmentsTest
-      - com.tle.webtests.test.contribute.controls.asc.AdvancedScriptControlTests
-      - com.tle.webtests.test.contribute.controls.asc.PropBagExTest
-      - com.tle.webtests.test.contribute.controls.asc.ScriptedDisplayTemplateTest
-      - com.tle.webtests.test.contribute.controls.asc.ScriptedPortletTests
-      - com.tle.webtests.test.reporting.RunReportTest
-      - com.tle.webtests.test.viewing.DisplayNodesTest
-      - com.tle.webtests.test.viewing.ItemHistoryTest
-      - com.tle.webtests.test.viewing.ItemServletRedirectTest
-      - com.tle.webtests.test.viewing.ItemSummaryTest
-      - com.tle.webtests.test.viewing.MimeTypesTest
-      #- com.tle.webtests.test.viewing.ModerationHistoryPreviewVal
-      #- com.tle.webtests.rewrite.ModerationRejectedComments
-      - com.tle.webtests.test.viewing.SearchResultTemplateTest
-      - com.tle.webtests.test.viewing.ServeSSITest
-      #- com.tle.webtests.test.viewing.ShowHideOwnerCollaborator
-      - com.tle.webtests.test.viewing.SummaryXSLTTest
-      - com.tle.webtests.test.viewing.VersionShowAllTest
-      - com.tle.webtests.test.viewing.ViewerTest
-      - com.tle.webtests.test.admin.CustomLinksTest
-      - com.tle.webtests.test.admin.ServerMessageTest
-      - com.tle.webtests.test.admin.MultiLingualTest
-      - com.tle.webtests.test.accessibility.AccessibilityModeTest
-      - com.tle.webtests.test.acl.ACLTest
-      - com.tle.webtests.test.cal.CALActivationsMetadataTest
-      - com.tle.webtests.test.cal.CALActivationsRolloverTest
-      - com.tle.webtests.test.cal.CALAgreementTest
-      - com.tle.webtests.test.cal.CALBookActivationTest
-      - com.tle.webtests.test.cal.CALBookRulesTest
-      - com.tle.webtests.test.cal.CALExtractTest
-      - com.tle.webtests.test.cal.CALJournalRulesTest
-      - com.tle.webtests.test.cal.CALPrivilegeTest
-      - com.tle.webtests.test.cal.CALSoapInterfaceTest
-      - com.tle.webtests.test.cal.CALViolationTest
-      - com.tle.webtests.test.dashboard.PortalsTest
-      - com.tle.webtests.test.drm.DRMPrivilegeTest
-      - com.tle.webtests.test.drm.DRMTest
-      - com.tle.webtests.test.drm.DRMTestWithCleanup
-      - com.tle.webtests.test.drm.WizardDRMTest
-      - com.tle.webtests.test.dynamichierarchy.DynamicHierarchyTest
-      - com.tle.webtests.test.importexport.CloneTest
-      - com.tle.webtests.test.importexport.ExportTest
-      - com.tle.webtests.test.importexport.ImportTest
-      - com.tle.webtests.test.myresources.favourites.FavouriteItemsTest
-      - com.tle.webtests.test.myresources.favourites.FavouritesInIntegrationTest
-      - com.tle.webtests.test.myresources.favourites.ResourceSelectorFavouritesTest
-      - com.tle.webtests.test.myresources.MyResourcesTest
-      - com.tle.webtests.test.myresources.MyResourcesWebPageTest
-      - com.tle.webtests.test.users.DisplayDateFormatTest
-      - com.tle.webtests.test.users.LoginSettingsTest
-      - com.tle.webtests.test.users.TokenLoginTest
-      - com.tle.webtests.test.users.UserPasswordTest
-      - com.tle.webtests.test.usersscripts.UserScriptTest
-      - com.tle.webtests.test.webservices.rest.ActivationApiTest
-      - com.tle.webtests.test.webservices.rest.CollectionApiTest
-      - com.tle.webtests.test.webservices.rest.CommentApiTest
-      - com.tle.webtests.test.webservices.rest.CourseApiTest
-      - com.tle.webtests.test.webservices.rest.DynaCollectionApiTest
-      - com.tle.webtests.test.webservices.rest.FileApiTest
-      - com.tle.webtests.test.webservices.rest.FileListingApiTest
-      - com.tle.webtests.test.webservices.rest.HierarchyApiTest
-      - com.tle.webtests.test.webservices.rest.ItemApiActionsTest
-      - com.tle.webtests.test.webservices.rest.ItemApiContributeTest
-      - com.tle.webtests.test.webservices.rest.ItemApiEditTest
-      - com.tle.webtests.test.webservices.rest.ItemApiLockTest
-      - com.tle.webtests.test.webservices.rest.ItemApiQuickContributeTest
-      - com.tle.webtests.test.webservices.rest.ItemApiRelationTest
-      - com.tle.webtests.test.webservices.rest.ItemApiViewTest
-      - com.tle.webtests.test.webservices.rest.MyResourcesApiTest
-      - com.tle.webtests.test.webservices.rest.NotificationsApiTest
-      - com.tle.webtests.test.webservices.rest.OAuthClientEditorTest
-      - com.tle.webtests.test.webservices.rest.SchemaApiTest
-      - com.tle.webtests.test.webservices.rest.ScrapbookApiTest
-      - com.tle.webtests.test.webservices.rest.SearchApiTest
-      - com.tle.webtests.test.webservices.rest.TasksApiTest
-      - com.tle.webtests.test.webservices.rest.TaxonomyApiTest
-      - com.tle.webtests.test.webservices.rest.UserGroupManagementApiTest
-      - com.tle.webtests.test.webservices.soap.Soap51Test
-      - com.tle.webtests.test.webservices.soap.SoapServicesTest
-      - com.tle.webtests.test.webservices.OAIEndpointTest
-      - com.tle.webtests.test.webservices.SRWTest
-      - com.tle.webtests.test.workflow.assignment.AutoAssignBiggerTest
-      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingByContributorRoleTest
-      - com.tle.webtests.test.workflow.assignment.AutoAssignSimpleTest
-      - com.tle.webtests.test.workflow.movetolive.MoveToLiveDuringWorkflowTest
-      - com.tle.webtests.test.workflow.assignment.WorkflowAssignmentTest
-      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingBySchemaElementTest
-      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingByItemStatusTest
-      - com.tle.webtests.test.workflow.rejection.NewVersionTest
-      - com.tle.webtests.test.workflow.rejection.RejectionPointsTest
-      - com.tle.webtests.test.workflow.rejection.RejectionPointsWithDecisionNodesTest
-      - com.tle.webtests.test.workflow.rejection.RejectionTest
-      - com.tle.webtests.test.workflow.ClonedItemTest
-      - com.tle.webtests.test.workflow.ManageTasksTest
-      - com.tle.webtests.test.workflow.MessageToModeratorTest
-      - com.tle.webtests.test.workflow.ModerationProgressTest
-      - com.tle.webtests.test.workflow.TaskListNavigationTest
-      - com.tle.webtests.test.workflow.TasksNotificationsTopbarTest
-      - com.tle.webtests.test.workflow.TasksSortingAndFilteringTest
+#      - com.tle.webtests.test.contribute.ResumableWizardsTest
+#      - com.tle.webtests.test.contribute.SelectAndDisplayThumbnailTest
+#      - com.tle.webtests.test.contribute.SelectionSessionTest
+#      - com.tle.webtests.test.contribute.StaticMetadataTest
+#      - com.tle.webtests.test.contribute.UniquenessTest
+#      - com.tle.webtests.test.contribute.VaryingContribPageNmbrSaveTest
+#      - com.tle.webtests.test.contribute.WizardBreadcrumbs
+#      - com.tle.webtests.test.contribute.WizardConfigTest
+#      - com.tle.webtests.test.contribute.controls.attachments.AttachmentControlTest
+#      - com.tle.webtests.test.contribute.controls.attachments.FileAttachmentControlTest
+#      - com.tle.webtests.test.contribute.controls.attachments.LTIAttachmentControlTest
+#      - com.tle.webtests.test.contribute.controls.attachments.MultipleAttachmentControlTest
+#      - com.tle.webtests.test.contribute.controls.attachments.RestrictedAttachmentsTest
+#      - com.tle.webtests.test.contribute.controls.asc.AdvancedScriptControlTests
+#      - com.tle.webtests.test.contribute.controls.asc.PropBagExTest
+#      - com.tle.webtests.test.contribute.controls.asc.ScriptedDisplayTemplateTest
+#      - com.tle.webtests.test.contribute.controls.asc.ScriptedPortletTests
+#      - com.tle.webtests.test.reporting.RunReportTest
+#      - com.tle.webtests.test.viewing.DisplayNodesTest
+#      - com.tle.webtests.test.viewing.ItemHistoryTest
+#      - com.tle.webtests.test.viewing.ItemServletRedirectTest
+#      - com.tle.webtests.test.viewing.ItemSummaryTest
+#      - com.tle.webtests.test.viewing.MimeTypesTest
+#- com.tle.webtests.test.viewing.ModerationHistoryPreviewVal
+#- com.tle.webtests.rewrite.ModerationRejectedComments
+#      - com.tle.webtests.test.viewing.SearchResultTemplateTest
+#      - com.tle.webtests.test.viewing.ServeSSITest
+#- com.tle.webtests.test.viewing.ShowHideOwnerCollaborator
+#      - com.tle.webtests.test.viewing.SummaryXSLTTest
+#      - com.tle.webtests.test.viewing.VersionShowAllTest
+#      - com.tle.webtests.test.viewing.ViewerTest
+#      - com.tle.webtests.test.admin.CustomLinksTest
+#      - com.tle.webtests.test.admin.ServerMessageTest
+#      - com.tle.webtests.test.admin.MultiLingualTest
+#      - com.tle.webtests.test.accessibility.AccessibilityModeTest
+#      - com.tle.webtests.test.acl.ACLTest
+#      - com.tle.webtests.test.cal.CALActivationsMetadataTest
+#      - com.tle.webtests.test.cal.CALActivationsRolloverTest
+#      - com.tle.webtests.test.cal.CALAgreementTest
+#      - com.tle.webtests.test.cal.CALBookActivationTest
+#      - com.tle.webtests.test.cal.CALBookRulesTest
+#      - com.tle.webtests.test.cal.CALExtractTest
+#      - com.tle.webtests.test.cal.CALJournalRulesTest
+#      - com.tle.webtests.test.cal.CALPrivilegeTest
+#      - com.tle.webtests.test.cal.CALSoapInterfaceTest
+#      - com.tle.webtests.test.cal.CALViolationTest
+#      - com.tle.webtests.test.dashboard.PortalsTest
+#      - com.tle.webtests.test.drm.DRMPrivilegeTest
+#      - com.tle.webtests.test.drm.DRMTest
+#      - com.tle.webtests.test.drm.DRMTestWithCleanup
+#      - com.tle.webtests.test.drm.WizardDRMTest
+#      - com.tle.webtests.test.dynamichierarchy.DynamicHierarchyTest
+#      - com.tle.webtests.test.importexport.CloneTest
+#      - com.tle.webtests.test.importexport.ExportTest
+#      - com.tle.webtests.test.importexport.ImportTest
+#      - com.tle.webtests.test.myresources.favourites.FavouriteItemsTest
+#      - com.tle.webtests.test.myresources.favourites.FavouritesInIntegrationTest
+#      - com.tle.webtests.test.myresources.favourites.ResourceSelectorFavouritesTest
+#      - com.tle.webtests.test.myresources.MyResourcesTest
+#      - com.tle.webtests.test.myresources.MyResourcesWebPageTest
+#      - com.tle.webtests.test.users.DisplayDateFormatTest
+#      - com.tle.webtests.test.users.LoginSettingsTest
+#      - com.tle.webtests.test.users.TokenLoginTest
+#      - com.tle.webtests.test.users.UserPasswordTest
+#      - com.tle.webtests.test.usersscripts.UserScriptTest
+#      - com.tle.webtests.test.webservices.rest.ActivationApiTest
+#      - com.tle.webtests.test.webservices.rest.CollectionApiTest
+#      - com.tle.webtests.test.webservices.rest.CommentApiTest
+#      - com.tle.webtests.test.webservices.rest.CourseApiTest
+#      - com.tle.webtests.test.webservices.rest.DynaCollectionApiTest
+#      - com.tle.webtests.test.webservices.rest.FileApiTest
+#      - com.tle.webtests.test.webservices.rest.FileListingApiTest
+#      - com.tle.webtests.test.webservices.rest.HierarchyApiTest
+#      - com.tle.webtests.test.webservices.rest.ItemApiActionsTest
+#      - com.tle.webtests.test.webservices.rest.ItemApiContributeTest
+#      - com.tle.webtests.test.webservices.rest.ItemApiEditTest
+#      - com.tle.webtests.test.webservices.rest.ItemApiLockTest
+#      - com.tle.webtests.test.webservices.rest.ItemApiQuickContributeTest
+#      - com.tle.webtests.test.webservices.rest.ItemApiRelationTest
+#      - com.tle.webtests.test.webservices.rest.ItemApiViewTest
+#      - com.tle.webtests.test.webservices.rest.MyResourcesApiTest
+#      - com.tle.webtests.test.webservices.rest.NotificationsApiTest
+#      - com.tle.webtests.test.webservices.rest.OAuthClientEditorTest
+#      - com.tle.webtests.test.webservices.rest.SchemaApiTest
+#      - com.tle.webtests.test.webservices.rest.ScrapbookApiTest
+#      - com.tle.webtests.test.webservices.rest.SearchApiTest
+#      - com.tle.webtests.test.webservices.rest.TasksApiTest
+#      - com.tle.webtests.test.webservices.rest.TaxonomyApiTest
+#      - com.tle.webtests.test.webservices.rest.UserGroupManagementApiTest
+#      - com.tle.webtests.test.webservices.soap.Soap51Test
+#      - com.tle.webtests.test.webservices.soap.SoapServicesTest
+#      - com.tle.webtests.test.webservices.OAIEndpointTest
+#      - com.tle.webtests.test.webservices.SRWTest
+#      - com.tle.webtests.test.workflow.assignment.AutoAssignBiggerTest
+#      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingByContributorRoleTest
+#      - com.tle.webtests.test.workflow.assignment.AutoAssignSimpleTest
+#      - com.tle.webtests.test.workflow.movetolive.MoveToLiveDuringWorkflowTest
+#      - com.tle.webtests.test.workflow.assignment.WorkflowAssignmentTest
+#      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingBySchemaElementTest
+#      - com.tle.webtests.test.workflow.rejection.DecisionPointScriptingByItemStatusTest
+#      - com.tle.webtests.test.workflow.rejection.NewVersionTest
+#      - com.tle.webtests.test.workflow.rejection.RejectionPointsTest
+#      - com.tle.webtests.test.workflow.rejection.RejectionPointsWithDecisionNodesTest
+#      - com.tle.webtests.test.workflow.rejection.RejectionTest
+#      - com.tle.webtests.test.workflow.ClonedItemTest
+#      - com.tle.webtests.test.workflow.ManageTasksTest
+#      - com.tle.webtests.test.workflow.MessageToModeratorTest
+#      - com.tle.webtests.test.workflow.ModerationProgressTest
+#      - com.tle.webtests.test.workflow.TaskListNavigationTest
+#      - com.tle.webtests.test.workflow.TasksNotificationsTopbarTest
+#      - com.tle.webtests.test.workflow.TasksSortingAndFilteringTest

--- a/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/ConfirmationDialog.java
+++ b/autotest/Tests/src/main/java/com/tle/webtests/pageobject/wizard/ConfirmationDialog.java
@@ -42,6 +42,13 @@ public class ConfirmationDialog extends AbstractPage<ConfirmationDialog> {
     return page.get();
   }
 
+  public WizardErrorPage publishErrorPage(WizardErrorPage page) {
+    confirm(ConfirmButton.PUBLISH);
+    // Wait for the error page is completed loaded
+    waiter.until(ExpectedConditions.visibilityOfElementLocated(By.cssSelector("div.error")));
+    return page.get();
+  }
+
   public SummaryPage publish() {
     confirm(ConfirmButton.PUBLISH);
     return new SummaryPage(context).get();


### PR DESCRIPTION
This test failed also because of not waiting for required page loaded. 
The reason for creating a new method called `publishErrorPage` is to avoid changes on `publishInvalid`  which is also used in other tests