### PR TITLE
remove unnecessary URL parameters

### DIFF
--- a/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMTest.java
+++ b/autotest/OldTests/src/test/java/com/tle/webtests/test/drm/DRMTest.java
@@ -282,7 +282,7 @@ public class DRMTest extends AbstractSessionTest {
   public void redirectTest() throws Exception {
     // DTEC 14600
     final String IMS_DOWNLOAD_URL =
-        "items/677a4bbc-defc-4dc1-b68e-4e2473b66a6a/1/viewims.jsp?viewMethod=download+old=true";
+        "items/677a4bbc-defc-4dc1-b68e-4e2473b66a6a/1/viewims.jsp?viewMethod=download";
 
     HomePage loginPage = logon("AutoTest", "automated");
     openUrl(IMS_DOWNLOAD_URL);


### PR DESCRIPTION
This test failed in Legacy UI because of a unnecessary URL parameter.

Not sure why @SammyIsConfused  added this parameter, but removing it does make the test pass in both Legacy and new UI locally.